### PR TITLE
making FileOverwriterOutputWriter.java backwards cmpatible.  It now look...

### DIFF
--- a/src/main/java/org/jmxtrans/agent/FileOverwriterOutputWriter.java
+++ b/src/main/java/org/jmxtrans/agent/FileOverwriterOutputWriter.java
@@ -37,6 +37,7 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 
 import static org.jmxtrans.agent.util.ConfigurationUtils.getString;
+import static org.jmxtrans.agent.util.ConfigurationUtils.getBoolean;
 
 /**
  * @author <a href="mailto:cleclerc@cloudbees.com">Cyrille Le Clerc</a>
@@ -45,9 +46,12 @@ public class FileOverwriterOutputWriter extends AbstractOutputWriter {
 
     public final static String SETTING_FILE_NAME = "fileName";
     public final static String SETTING_FILE_NAME_DEFAULT_VALUE = "jmxtrans-agent.data";
+    public final static String SETTING_SHOW_TIMESTAMP = "showTimeStamp";
+    public final static Boolean SETTING_SHOW_TIMESTAMP_DEFAULT = false;
     protected Writer temporaryFileWriter;
     protected File temporaryFile;
     protected File file = new File(SETTING_FILE_NAME_DEFAULT_VALUE);
+    protected Boolean showTimeStamp;
     private static Calendar cal = Calendar.getInstance(TimeZone.getTimeZone("GMT"));
     private static DateFormat dfISO8601 = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm'Z'");
     
@@ -56,6 +60,7 @@ public class FileOverwriterOutputWriter extends AbstractOutputWriter {
         super.postConstruct(settings);
         dfISO8601.setTimeZone(TimeZone.getTimeZone("GMT"));
         file = new File(getString(settings, SETTING_FILE_NAME, SETTING_FILE_NAME_DEFAULT_VALUE));
+        showTimeStamp = getBoolean(settings, SETTING_SHOW_TIMESTAMP, SETTING_SHOW_TIMESTAMP_DEFAULT);
         logger.log(getInfoLevel(), "FileOverwriterOutputWriter configured with file " + file.getAbsolutePath());
     }
 
@@ -82,7 +87,12 @@ public class FileOverwriterOutputWriter extends AbstractOutputWriter {
 
     public synchronized void writeQueryResult(@Nonnull String name, @Nullable String type, @Nullable Object value) throws IOException {
         try {
-            getTemporaryFileWriter().write("["+dfISO8601.format(Calendar.getInstance().getTime()) +"] "+name + " " + value + "\n");
+            if (showTimeStamp){
+                getTemporaryFileWriter().write("["+dfISO8601.format(Calendar.getInstance().getTime()) +"] "+name + " " + value + "\n");
+            } else {
+                getTemporaryFileWriter().write(name + " " + value + "\n");
+            }
+            
         } catch (IOException e) {
             releaseTemporaryWriter();
             throw e;


### PR DESCRIPTION
...s for the <showTimeStamp> optional tag in configuration.  Defaults to false.

When config looks like this:

```
<outputWriter class="org.jmxtrans.agent.FileOverwriterOutputWriter">
      <fileName>jmxOutputFile</fileName>
      <showTimeStamp>true</showTimeStamp>
</outputWriter>
```

Output looks like this:

```
[2014-10-27T13:01Z] jvm.heapMemoryUsage.committed 582483968
[2014-10-27T13:01Z] jvm.nonHeapMemoryUsage.used 29967688
[2014-10-27T13:01Z] jvm.nonHeapMemoryUsage.committed 43122688
[2014-10-27T13:01Z] jvm.loadedClasses 4098
[2014-10-27T13:01Z] jvm.thread 32
[2014-10-27T13:01Z] tomcat.requestCount 8
[2014-10-27T13:01Z] tomcat.requestCount 0
[2014-10-27T13:01Z] tomcat.errorCount 0
[2014-10-27T13:01Z] tomcat.errorCount 0
[2014-10-27T13:01Z] tomcat.processingTime 545
[2014-10-27T13:01Z] tomcat.processingTime 0
[2014-10-27T13:01Z] tomcat.bytesSent 47373
[2014-10-27T13:01Z] tomcat.bytesSent 0
[2014-10-27T13:01Z] tomcat.bytesReceived 0
[2014-10-27T13:01Z] tomcat.bytesReceived 0
[2014-10-27T13:01Z] application.activeSessions 0
```

When config looks like this:

```
<outputWriter class="org.jmxtrans.agent.FileOverwriterOutputWriter">
      <fileName>jmxOutputFile</fileName>
</outputWriter>
```

Output looks like this:

```
os.systemLoadAverage 1.2041015625
jvm.heapMemoryUsage.used 78076928
jvm.heapMemoryUsage.committed 593494016
jvm.nonHeapMemoryUsage.used 30075208
jvm.nonHeapMemoryUsage.committed 44236800
jvm.loadedClasses 4095
jvm.thread 26
tomcat.requestCount 1
tomcat.requestCount 0
tomcat.errorCount 0
tomcat.errorCount 0
tomcat.processingTime 530
tomcat.processingTime 0
tomcat.bytesSent 11398
tomcat.bytesSent 0
tomcat.bytesReceived 0
tomcat.bytesReceived 0
```

Should be 100% backwards compatible.
