### PR TITLE
expanding possibilities of the agent configuration

### DIFF
--- a/src/main/java/org/jmxtrans/agent/JConsoleNameStrategy.java
+++ b/src/main/java/org/jmxtrans/agent/JConsoleNameStrategy.java
@@ -1,0 +1,35 @@
+package org.jmxtrans.agent;
+
+import javax.management.ObjectName;
+import java.util.Map;
+
+public class JConsoleNameStrategy implements ResultNameStrategy {
+    @Override
+    public String getResultName(Query query, ObjectName objectName, String key, String attribute) {
+        String result = objectName.getDomain();
+        if(objectName.getKeyProperty("type") != null) {
+            result += "." + objectName.getKeyProperty("type");
+        }
+        if(objectName.getKeyProperty("name") != null) {
+            result += "." + objectName.getKeyProperty("name");
+        }
+        for (Map.Entry<String, String> entry : objectName.getKeyPropertyList().entrySet()) {
+            if(!entry.getKey().equalsIgnoreCase("name") && !entry.getKey().equalsIgnoreCase("type")){
+                result += "." + entry.getValue();
+            }
+        }
+
+        result += "." + attribute;
+
+        if(key != null && !key.isEmpty()){
+            result = result + "." + key;
+        }
+
+        return result;
+    }
+
+    @Override
+    public void postConstruct(Map<String, String> settings) {
+
+    }
+}

--- a/src/main/java/org/jmxtrans/agent/ResultNameStrategy.java
+++ b/src/main/java/org/jmxtrans/agent/ResultNameStrategy.java
@@ -90,9 +90,7 @@ import java.util.Map;
 public interface ResultNameStrategy {
 
     @Nonnull
-    String getResultName(@Nonnull Query query, @Nonnull ObjectName objectName);
-    @Nonnull
-    String getResultName(@Nonnull Query query, @Nonnull ObjectName objectName, @Nullable String key);
+    String getResultName(@Nonnull Query query, @Nonnull ObjectName objectName, @Nullable String key, @Nullable String attribute);
 
     void postConstruct(@Nonnull Map<String, String> settings);
 }

--- a/src/main/java/org/jmxtrans/agent/ResultNameStrategyImpl.java
+++ b/src/main/java/org/jmxtrans/agent/ResultNameStrategyImpl.java
@@ -100,19 +100,13 @@ public class ResultNameStrategyImpl implements ResultNameStrategy {
 
     @Nonnull
     @Override
-    public String getResultName(@Nonnull Query query, @Nonnull ObjectName objectName) {
-        return getResultName(query, objectName, null);
-    }
-
-    @Nonnull
-    @Override
-    public String getResultName(@Nonnull Query query, @Nonnull ObjectName objectName, @Nullable String key) {
+    public String getResultName(@Nonnull Query query, @Nonnull ObjectName objectName, @Nullable String key, @Nonnull String attribute) {
         String result;
         if (query.getResultAlias() == null) {
             if(key == null) {
-                result = escapeObjectName(objectName) + "." + query.getAttribute();
+                result = escapeObjectName(objectName) + "." + attribute;
             } else {
-                result = escapeObjectName(objectName) + "." + query.getAttribute() + "." + key;
+                result = escapeObjectName(objectName) + "." + attribute + "." + key;
             }
         } else {
             result = expressionLanguageEngine.resolveExpression(query.getResultAlias(), objectName);


### PR DESCRIPTION
Adding more power for XML configuration
- adding support for ALL attributes, when no attribute is specified
- adding support for ALL keys, when no key is specified for CompositTypes

More general rules for name creation - people who are familiar with JConsole / VisualVM should like such naming utility
- introduce JConsole like naming strategy

My Idea noticed that one method was not used anymore
- removed unused method from interface

It generally will run trivial configuration, that will send all jmx data to graphite. 

    <jmxtrans-agent>
        <queries>        			  
    		<query/>        
        </queries>
        <outputWriter class="org.jmxtrans.agent.GraphitePlainTextTcpOutputWriter">
            <host>172.17.0.64</host>
            <port>2003</port>
            <namePrefix>offer-parsers-service.</namePrefix>
        </outputWriter>
        <outputWriter class="org.jmxtrans.agent.ConsoleOutputWriter"/>
    	<resultNameStrategy class="org.jmxtrans.agent.JConsoleNameStrategy"/>
        <collectIntervalInSeconds>20</collectIntervalInSeconds>
    </jmxtrans-agent>