### PR TITLE
Removed initial logging since it interfered with Jenkins logging

### DIFF
--- a/src/main/java/org/jmxtrans/agent/JmxTransAgent.java
+++ b/src/main/java/org/jmxtrans/agent/JmxTransAgent.java
@@ -45,6 +45,7 @@ public class JmxTransAgent {
             jmxTransExporter = new JmxTransExporterBuilder().build(configFile);
             //START
             jmxTransExporter.start();
+            System.out.println("JmxTransAgent started with configuration '" + configFile + "'");
         } catch (Exception e) {
             String msg = "Exception loading JmxTransExporter from '" + configFile + "'";
             logger.log(Level.SEVERE, msg, e);

--- a/src/main/java/org/jmxtrans/agent/JmxTransAgent.java
+++ b/src/main/java/org/jmxtrans/agent/JmxTransAgent.java
@@ -45,7 +45,6 @@ public class JmxTransAgent {
             jmxTransExporter = new JmxTransExporterBuilder().build(configFile);
             //START
             jmxTransExporter.start();
-            logger.info("JmxTransAgent started with configuration '" + configFile + "'");
         } catch (Exception e) {
             String msg = "Exception loading JmxTransExporter from '" + configFile + "'";
             logger.log(Level.SEVERE, msg, e);


### PR DESCRIPTION
Tried to use jmxtrans-agent on a Jenkins master and since it started logging with JUL before Jenkins initialized is JUL configuration, the logging in Jenkins became very strange. By just removing the initial logging in the agent logging the issue was resolved.