### PR TITLE
Add attribute and key name to resultName generated by ExpressionLanguageEngine

### DIFF
--- a/src/main/java/org/jmxtrans/agent/ResultNameStrategyImpl.java
+++ b/src/main/java/org/jmxtrans/agent/ResultNameStrategyImpl.java
@@ -103,24 +103,16 @@ public class ResultNameStrategyImpl implements ResultNameStrategy {
     @Nonnull
     @Override
     public String getResultName(@Nonnull Query query, @Nonnull ObjectName objectName, @Nullable String key, @Nonnull String attribute) {
-        /** Find alias */
         String result;
         if (query.getResultAlias() == null) {
-            result = escapeObjectName(objectName);
+            if(key == null) {
+                result = escapeObjectName(objectName) + "." + attribute;
+            } else {
+                result = escapeObjectName(objectName) + "." + attribute + "." + key;
+            }
         } else {
             result = expressionLanguageEngine.resolveExpression(query.getResultAlias(), objectName);
         }
-
-        /** Append attribute, if any */
-        if (attribute != null && !attribute.isEmpty()) {
-            result += "." + attribute;
-        }
-
-        /** Append compositeData key, if any */
-        if (key != null && !key.isEmpty()) {
-            result += "." + key;
-        }
-
         return result;
     }
 

--- a/src/main/java/org/jmxtrans/agent/ResultNameStrategyImpl.java
+++ b/src/main/java/org/jmxtrans/agent/ResultNameStrategyImpl.java
@@ -103,16 +103,24 @@ public class ResultNameStrategyImpl implements ResultNameStrategy {
     @Nonnull
     @Override
     public String getResultName(@Nonnull Query query, @Nonnull ObjectName objectName, @Nullable String key, @Nonnull String attribute) {
+        /** Find alias */
         String result;
         if (query.getResultAlias() == null) {
-            if(key == null) {
-                result = escapeObjectName(objectName) + "." + attribute;
-            } else {
-                result = escapeObjectName(objectName) + "." + attribute + "." + key;
-            }
+            result = escapeObjectName(objectName);
         } else {
             result = expressionLanguageEngine.resolveExpression(query.getResultAlias(), objectName);
         }
+
+        /** Append attribute, if any */
+        if (attribute != null && !attribute.isEmpty()) {
+            result += "." + attribute;
+        }
+
+        /** Append compositeData key, if any */
+        if (key != null && !key.isEmpty()) {
+            result += "." + key;
+        }
+
         return result;
     }
 

--- a/src/test/java/org/jmxtrans/agent/QueryTest.java
+++ b/src/test/java/org/jmxtrans/agent/QueryTest.java
@@ -71,9 +71,9 @@ public class QueryTest {
 
     @Test
     public void basic_attribute_return_simple_result() throws Exception {
-        Query query = new Query("test:type=Mock,name=mock", "CollectionUsageThreshold", resultNameStrategy);
+        Query query = new Query("test:type=Mock,name=mock", "CollectionUsageThreshold", null, resultNameStrategy);
         query.collectAndExport(mbeanServer, mockOutputWriter);
-        Object actual = mockOutputWriter.resultsByName.get("CollectionUsageThreshold");
+        Object actual = mockOutputWriter.resultsByName.get("test.name__mock.type__Mock.CollectionUsageThreshold");
         assertThat(actual, notNullValue());
         assertThat(actual, instanceOf(Number.class));
     }
@@ -89,7 +89,7 @@ public class QueryTest {
 
     @Test
     public void expression_language_substitutes_object_name_key() throws Exception {
-        Query query = new Query("test:type=Mock,name=mock", "CollectionUsageThreshold", "test_%type%_%name%.CollectionUsageThreshold", resultNameStrategy);
+        Query query = new Query("test:type=Mock,name=mock", "CollectionUsageThreshold", "test_%type%_%name%", resultNameStrategy);
         query.collectAndExport(mbeanServer, mockOutputWriter);
         Object actual = mockOutputWriter.resultsByName.get("test_Mock_mock.CollectionUsageThreshold");
         assertThat(actual, notNullValue());
@@ -102,7 +102,7 @@ public class QueryTest {
         engine.registerExpressionEvaluator("hostname", "my-hostname");
         ResultNameStrategyImpl resultNameStrategy = new ResultNameStrategyImpl();
         resultNameStrategy.setExpressionLanguageEngine(engine);
-        Query query = new Query("test:type=Mock,name=mock", "CollectionUsageThreshold", "#hostname#.mock.CollectionUsageThreshold", resultNameStrategy);
+        Query query = new Query("test:type=Mock,name=mock", "CollectionUsageThreshold", "#hostname#.mock", resultNameStrategy);
         query.collectAndExport(mbeanServer, mockOutputWriter);
         Object actual = mockOutputWriter.resultsByName.get("my-hostname.mock.CollectionUsageThreshold");
         assertThat(actual, notNullValue());
@@ -113,18 +113,18 @@ public class QueryTest {
     public void indexed_list_attribute_return_simple_result() throws Exception {
         Query query = new Query("test:type=Mock,name=mock", "IntegerList", 1, resultNameStrategy);
         query.collectAndExport(mbeanServer, mockOutputWriter);
-        Object actual = mockOutputWriter.resultsByName.get("IntegerList");
+        Object actual = mockOutputWriter.resultsByName.get("IntegerList.IntegerList");
         assertThat(actual, notNullValue());
         assertThat(actual, instanceOf(Number.class));
     }
 
     @Test
     public void non_indexed_list_attribute_return_simple_result() throws Exception {
-        Query query = new Query("test:type=Mock,name=mock", "IntegerList", resultNameStrategy);
+        Query query = new Query("test:type=Mock,name=mock", "IntegerList", null, resultNameStrategy);
         query.collectAndExport(mbeanServer, mockOutputWriter);
 
         for (int i = 0; i < mock.getIntegerList().size(); i++) {
-            String name = "IntegerList_" + i;
+            String name = "test.name__mock.type__Mock.IntegerList_" + i;
             Object actual = mockOutputWriter.resultsByName.get(name);
             assertThat("Result '" + name + "' is missing", actual, notNullValue());
             assertThat("Result '" + name + "' type is invalid", actual, instanceOf(Number.class));
@@ -135,7 +135,7 @@ public class QueryTest {
     public void indexed_int_array_attribute_return_simple_result() throws Exception {
         Query query = new Query("test:type=Mock,name=mock", "IntArray", 1, resultNameStrategy);
         query.collectAndExport(mbeanServer, mockOutputWriter);
-        Object actual = mockOutputWriter.resultsByName.get("IntArray");
+        Object actual = mockOutputWriter.resultsByName.get("IntArray.IntArray");
         assertThat(actual, notNullValue());
         assertThat(actual, instanceOf(Number.class));
     }
@@ -144,7 +144,7 @@ public class QueryTest {
     public void indexed_integer_array_attribute_return_simple_result() throws Exception {
         Query query = new Query("test:type=Mock,name=mock", "IntegerArray", 1, resultNameStrategy);
         query.collectAndExport(mbeanServer, mockOutputWriter);
-        Object actual = mockOutputWriter.resultsByName.get("IntegerArray");
+        Object actual = mockOutputWriter.resultsByName.get("IntegerArray.IntegerArray");
         assertThat(actual, notNullValue());
         assertThat(actual, instanceOf(Number.class));
     }
@@ -168,10 +168,10 @@ public class QueryTest {
     }
 
     @Test
-    public void query_wildcard_objectname_domain_returns_meabn_with_resultalias() throws Exception {
+    public void query_wildcard_objectname_domain_returns_mbean_with_resultalias() throws Exception {
         Query query = new Query("*:type=Mock,name=mock", "CollectionUsageThreshold", "altTest.%name%.%type%", resultNameStrategy);
         query.collectAndExport(mbeanServer, mockOutputWriter);
-        Object actual = mockOutputWriter.resultsByName.get("altTest.mock.Mock");
+        Object actual = mockOutputWriter.resultsByName.get("altTest.mock.Mock.CollectionUsageThreshold");
         assertThat(actual, notNullValue());
         assertThat(actual, instanceOf(Number.class));
     }
@@ -180,7 +180,7 @@ public class QueryTest {
     public void query_wildcard_objectname_property_returns_mbean_with_resultalias() throws Exception {
         Query query = new Query("test:*", "CollectionUsageThreshold", "altTest.%name%.%type%", resultNameStrategy);
         query.collectAndExport(mbeanServer, mockOutputWriter);
-        Object actual = mockOutputWriter.resultsByName.get("altTest.mock.Mock");
+        Object actual = mockOutputWriter.resultsByName.get("altTest.mock.Mock.CollectionUsageThreshold");
         assertThat(actual, notNullValue());
         assertThat(actual, instanceOf(Number.class));
     }

--- a/src/test/java/org/jmxtrans/agent/QueryTest.java
+++ b/src/test/java/org/jmxtrans/agent/QueryTest.java
@@ -71,9 +71,9 @@ public class QueryTest {
 
     @Test
     public void basic_attribute_return_simple_result() throws Exception {
-        Query query = new Query("test:type=Mock,name=mock", "CollectionUsageThreshold", null, resultNameStrategy);
+        Query query = new Query("test:type=Mock,name=mock", "CollectionUsageThreshold", resultNameStrategy);
         query.collectAndExport(mbeanServer, mockOutputWriter);
-        Object actual = mockOutputWriter.resultsByName.get("test.name__mock.type__Mock.CollectionUsageThreshold");
+        Object actual = mockOutputWriter.resultsByName.get("CollectionUsageThreshold");
         assertThat(actual, notNullValue());
         assertThat(actual, instanceOf(Number.class));
     }
@@ -89,7 +89,7 @@ public class QueryTest {
 
     @Test
     public void expression_language_substitutes_object_name_key() throws Exception {
-        Query query = new Query("test:type=Mock,name=mock", "CollectionUsageThreshold", "test_%type%_%name%", resultNameStrategy);
+        Query query = new Query("test:type=Mock,name=mock", "CollectionUsageThreshold", "test_%type%_%name%.CollectionUsageThreshold", resultNameStrategy);
         query.collectAndExport(mbeanServer, mockOutputWriter);
         Object actual = mockOutputWriter.resultsByName.get("test_Mock_mock.CollectionUsageThreshold");
         assertThat(actual, notNullValue());
@@ -102,7 +102,7 @@ public class QueryTest {
         engine.registerExpressionEvaluator("hostname", "my-hostname");
         ResultNameStrategyImpl resultNameStrategy = new ResultNameStrategyImpl();
         resultNameStrategy.setExpressionLanguageEngine(engine);
-        Query query = new Query("test:type=Mock,name=mock", "CollectionUsageThreshold", "#hostname#.mock", resultNameStrategy);
+        Query query = new Query("test:type=Mock,name=mock", "CollectionUsageThreshold", "#hostname#.mock.CollectionUsageThreshold", resultNameStrategy);
         query.collectAndExport(mbeanServer, mockOutputWriter);
         Object actual = mockOutputWriter.resultsByName.get("my-hostname.mock.CollectionUsageThreshold");
         assertThat(actual, notNullValue());
@@ -113,18 +113,18 @@ public class QueryTest {
     public void indexed_list_attribute_return_simple_result() throws Exception {
         Query query = new Query("test:type=Mock,name=mock", "IntegerList", 1, resultNameStrategy);
         query.collectAndExport(mbeanServer, mockOutputWriter);
-        Object actual = mockOutputWriter.resultsByName.get("IntegerList.IntegerList");
+        Object actual = mockOutputWriter.resultsByName.get("IntegerList");
         assertThat(actual, notNullValue());
         assertThat(actual, instanceOf(Number.class));
     }
 
     @Test
     public void non_indexed_list_attribute_return_simple_result() throws Exception {
-        Query query = new Query("test:type=Mock,name=mock", "IntegerList", null, resultNameStrategy);
+        Query query = new Query("test:type=Mock,name=mock", "IntegerList", resultNameStrategy);
         query.collectAndExport(mbeanServer, mockOutputWriter);
 
         for (int i = 0; i < mock.getIntegerList().size(); i++) {
-            String name = "test.name__mock.type__Mock.IntegerList_" + i;
+            String name = "IntegerList_" + i;
             Object actual = mockOutputWriter.resultsByName.get(name);
             assertThat("Result '" + name + "' is missing", actual, notNullValue());
             assertThat("Result '" + name + "' type is invalid", actual, instanceOf(Number.class));
@@ -135,7 +135,7 @@ public class QueryTest {
     public void indexed_int_array_attribute_return_simple_result() throws Exception {
         Query query = new Query("test:type=Mock,name=mock", "IntArray", 1, resultNameStrategy);
         query.collectAndExport(mbeanServer, mockOutputWriter);
-        Object actual = mockOutputWriter.resultsByName.get("IntArray.IntArray");
+        Object actual = mockOutputWriter.resultsByName.get("IntArray");
         assertThat(actual, notNullValue());
         assertThat(actual, instanceOf(Number.class));
     }
@@ -144,7 +144,7 @@ public class QueryTest {
     public void indexed_integer_array_attribute_return_simple_result() throws Exception {
         Query query = new Query("test:type=Mock,name=mock", "IntegerArray", 1, resultNameStrategy);
         query.collectAndExport(mbeanServer, mockOutputWriter);
-        Object actual = mockOutputWriter.resultsByName.get("IntegerArray.IntegerArray");
+        Object actual = mockOutputWriter.resultsByName.get("IntegerArray");
         assertThat(actual, notNullValue());
         assertThat(actual, instanceOf(Number.class));
     }
@@ -168,10 +168,10 @@ public class QueryTest {
     }
 
     @Test
-    public void query_wildcard_objectname_domain_returns_mbean_with_resultalias() throws Exception {
+    public void query_wildcard_objectname_domain_returns_meabn_with_resultalias() throws Exception {
         Query query = new Query("*:type=Mock,name=mock", "CollectionUsageThreshold", "altTest.%name%.%type%", resultNameStrategy);
         query.collectAndExport(mbeanServer, mockOutputWriter);
-        Object actual = mockOutputWriter.resultsByName.get("altTest.mock.Mock.CollectionUsageThreshold");
+        Object actual = mockOutputWriter.resultsByName.get("altTest.mock.Mock");
         assertThat(actual, notNullValue());
         assertThat(actual, instanceOf(Number.class));
     }
@@ -180,7 +180,7 @@ public class QueryTest {
     public void query_wildcard_objectname_property_returns_mbean_with_resultalias() throws Exception {
         Query query = new Query("test:*", "CollectionUsageThreshold", "altTest.%name%.%type%", resultNameStrategy);
         query.collectAndExport(mbeanServer, mockOutputWriter);
-        Object actual = mockOutputWriter.resultsByName.get("altTest.mock.Mock.CollectionUsageThreshold");
+        Object actual = mockOutputWriter.resultsByName.get("altTest.mock.Mock");
         assertThat(actual, notNullValue());
         assertThat(actual, instanceOf(Number.class));
     }

--- a/src/test/java/org/jmxtrans/agent/ResultNameStrategyTest.java
+++ b/src/test/java/org/jmxtrans/agent/ResultNameStrategyTest.java
@@ -88,4 +88,12 @@ public class ResultNameStrategyTest {
         String actual = engine.resolveExpression("#canonical_hostname#");
         assertThat(actual, is("server1.mycompany.com"));
     }
+
+    @Test
+    public void testGetResultName() throws Exception {
+        Query query = new Query("*:*", "count", "Katalina.%name%.%type%", strategy);
+        String objectName = "Catalina:type=Resource,resourcetype=Context,host=localhost,class=javax.sql.DataSource,name=\"jdbc/my-datasource\"";
+        String actual = strategy.getResultName(query, new ObjectName(objectName), "usage", "count");
+        assertThat(actual, is("Katalina.jdbc_my-datasource.Resource.count.usage"));
+    }
 }


### PR DESCRIPTION
Adding such strings make the resultName self-explanatory, especially when wildcarding the objectName or attributes.
    
Fixes #39
    
Sponsored by: Lookout, Inc.
