### PR TITLE
Add support for dynamic agent attachement

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -51,6 +51,13 @@
             <version>2.6.0</version>
 	</dependency>
         <dependency>
+            <groupId>com.sun</groupId>
+            <artifactId>tools</artifactId>
+            <version>1.4.2</version>
+            <scope>system</scope>
+            <systemPath>${java.home}/../lib/tools.jar</systemPath>
+        </dependency>
+        <dependency>
             <groupId>com.google.code.findbugs</groupId>
             <artifactId>jsr305</artifactId>
             <version>2.0.1</version>
@@ -91,6 +98,7 @@
                     <archive>
                         <manifestEntries>
                             <Premain-Class>org.jmxtrans.agent.JmxTransAgent</Premain-Class>
+                            <Agent-Class>org.jmxtrans.agent.JmxTransAgent</Agent-Class>
                         </manifestEntries>
                     </archive>
                 </configuration>
@@ -134,6 +142,7 @@
                     <archive>
                         <manifestEntries>
                             <Premain-Class>org.jmxtrans.agent.JmxTransAgent</Premain-Class>
+                            <Agent-Class>org.jmxtrans.agent.JmxTransAgent</Agent-Class>
                         </manifestEntries>
                     </archive>
         </configuration>

--- a/src/main/java/org/jmxtrans/agent/DynamicallyAgentAttacher.java
+++ b/src/main/java/org/jmxtrans/agent/DynamicallyAgentAttacher.java
@@ -1,0 +1,42 @@
+package org.jmxtrans.agent;
+
+import com.sun.tools.attach.VirtualMachine;
+import org.jmxtrans.agent.util.logging.Logger;
+
+public class DynamicallyAgentAttacher {
+    private static Logger logger = Logger.getLogger(DynamicallyAgentAttacher.class.getName());
+
+    public static void main(String[] args) {
+        if(args.length != 3) {
+            printUsage();
+            System.exit(1);
+        }
+
+        String agentJarPath = args[0];
+        String targetJvmPid = args[1];
+        String configurationFile = args[2];
+        logger.info("Dynamically loading jmxtrans-agent");
+        logger.info("Agent path: " + agentJarPath);
+        logger.info("Target JVM PID: " + targetJvmPid);
+        logger.info("XML configuration file: " + configurationFile);
+
+        try {
+            VirtualMachine vm = VirtualMachine.attach(targetJvmPid);
+            vm.loadAgent(agentJarPath, configurationFile);
+            vm.detach();
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+    }
+
+    private static void printUsage() {
+        System.err.println("Usage: java -jar jmxtrans-agent.jar <agent-absolute-path> <target-jvm-pid> " +
+                "<xml-configuration-file>");
+        System.err.println("Dynamically attaches jmxtrans-agent to a running JVM");
+        System.err.println("");
+        System.err.println("Mandatory arguments:");
+        System.err.println(" agent-absolute-path      Absolute path to jmxtrans-agent JAR file");
+        System.err.println(" target-jvm-pid           Target JVM PID on which the agent will be attached");
+        System.err.println(" xml-configuration-file   Absolute path to agent XML configuration file");
+    }
+}

--- a/src/main/java/org/jmxtrans/agent/JmxTransAgent.java
+++ b/src/main/java/org/jmxtrans/agent/JmxTransAgent.java
@@ -48,8 +48,15 @@ public class JmxTransAgent {
     @SuppressFBWarnings("MS_SHOULD_BE_FINAL")
     public static boolean DIAGNOSTIC = Boolean.valueOf(System.getProperty(JmxTransAgent.class.getName() + ".diagnostic", "false"));
 
-    public static void premain(String configFile, Instrumentation inst) {
+    public static void agentmain(String configFile, Instrumentation inst) {
+        initializeAgent(configFile);
+    }
 
+    public static void premain(String configFile, Instrumentation inst) {
+        initializeAgent(configFile);
+    }
+
+    private static void initializeAgent(String configFile) {
         dumpDiagnosticInfo();
         if (configFile == null || configFile.isEmpty()) {
             String msg = "JmxTransExporter configurationFile must be defined";


### PR DESCRIPTION
With an "agentmain" method, it is possible to attach the agent to a running JVM.  This PR adds a new class that connects to an existing JVM and attach the agent after the fact.

To use the agent, the absolute paths to both the agent JAR and its configuration must be passed to the launcher, along with the target JVM PID.

Example, assuming the agent is in `/tmp/`, the configuration file is `/tmp/sample-config.xml` and the target JVM has PID `1234`, run the following:

```sh
java \
  -cp $JAVA_HOME/lib/tools.jar:/tmp/jmxtrans-agent-1.1.1-SNAPSHOT.jar \
  org.jmxtrans.agent.DynamicallyAgentAttacher \
  /tmp/jmxtrans-agent-1.1.1-SNAPSHOT.jar \
  1234 \
  /tmp/sample-config.xml
```