### PR TITLE
Cleanup code so that mvn verify passes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,8 @@
  ~ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  ~
 -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.sonatype.oss</groupId>
@@ -41,15 +42,15 @@
     </scm>
     <dependencies>
         <dependency>
-	    <groupId>com.fasterxml.jackson.core</groupId>
-	    <artifactId>jackson-annotations</artifactId>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-annotations</artifactId>
             <version>2.6.0</version>
-	</dependency>
-	<dependency>
-	    <groupId>com.fasterxml.jackson.core</groupId>
-	    <artifactId>jackson-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
             <version>2.6.0</version>
-	</dependency>
+        </dependency>
         <dependency>
             <groupId>com.sun</groupId>
             <artifactId>tools</artifactId>
@@ -125,28 +126,28 @@
                     </execution>
                 </executions>
             </plugin>
-<plugin>
-        <artifactId>maven-assembly-plugin</artifactId>
-        <executions>
-          <execution>
-            <phase>package</phase>
-            <goals>
-              <goal>single</goal>
-            </goals>
-          </execution>
-        </executions>
-        <configuration>
-          <descriptorRefs>
-            <descriptorRef>jar-with-dependencies</descriptorRef>
-          </descriptorRefs>
+            <plugin>
+                <artifactId>maven-assembly-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>single</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <descriptorRefs>
+                        <descriptorRef>jar-with-dependencies</descriptorRef>
+                    </descriptorRefs>
                     <archive>
                         <manifestEntries>
                             <Premain-Class>org.jmxtrans.agent.JmxTransAgent</Premain-Class>
                             <Agent-Class>org.jmxtrans.agent.JmxTransAgent</Agent-Class>
                         </manifestEntries>
                     </archive>
-        </configuration>
-      </plugin>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
     <developers>

--- a/src/main/java/org/jmxtrans/agent/LibratoWriter.java
+++ b/src/main/java/org/jmxtrans/agent/LibratoWriter.java
@@ -64,11 +64,8 @@ public class LibratoWriter extends AbstractOutputWriter implements OutputWriter 
 
     @Override
     public synchronized void postConstruct(Map<String, String> settings) {
-        final String user = ConfigurationUtils.getString(settings, SETTING_USERNAME);
-        final String token = ConfigurationUtils.getString(settings, SETTING_TOKEN);
-        if (user == null || token == null) {
-            throw new RuntimeException("Username and/or token cannot be null");
-        }
+        user = ConfigurationUtils.getString(settings, SETTING_USERNAME);
+        token = ConfigurationUtils.getString(settings, SETTING_TOKEN);
         basicAuthentication = Base64Variants.getDefaultVariant().encode((user + ":" + token).getBytes(Charset.forName("US-ASCII")));
         httpUserAgent = "jmxtrans-standalone/1 " + "(" +
 						System.getProperty("java.vm.name") + "/" + System.getProperty("java.version") + "; " +
@@ -93,11 +90,10 @@ public class LibratoWriter extends AbstractOutputWriter implements OutputWriter 
     }
 
     @Override
-    public synchronized void writeQueryResult(String metricName, String metricType, Object value) throws IOException {
-		HttpURLConnection urlConnection = null;
+    public synchronized void writeQueryResult(String metricName, String metricType, Object value) {
 		try {
-			urlConnection = (HttpURLConnection) url.openConnection();
-			urlConnection.setRequestMethod("POST");
+            HttpURLConnection urlConnection = (HttpURLConnection) url.openConnection();
+            urlConnection.setRequestMethod("POST");
             urlConnection.setDoInput(true);
             urlConnection.setDoOutput(true);
             urlConnection.setRequestProperty("content-type", "application/json; charset=utf-8");
@@ -109,7 +105,6 @@ public class LibratoWriter extends AbstractOutputWriter implements OutputWriter 
 			g.writeArrayFieldStart("gauges");
 			g.writeStartObject();
 			g.writeStringField("name", metricName);
-			//g.writeNumberField("measure_time", gauge.getEpoch(TimeUnit.SECONDS));
 			if (value instanceof Integer) {
                 g.writeNumberField("value", (Integer) value);
             } else if (value instanceof Long) {
@@ -129,8 +124,8 @@ public class LibratoWriter extends AbstractOutputWriter implements OutputWriter 
             if (responseCode != 200) {
                 logger.info(String.format("Failure %d:'%s' to send result to Librato server '%s', user %s", responseCode, urlConnection.getResponseMessage(), url, user));
             }
-		} catch (Exception e) {
+		} catch (IOException e) {
 			logger.info(String.format("Failure to send result to Librato server '%s' user %s", url, user));
-		} 
+		}
     }
 }


### PR DESCRIPTION
A previous PR included:
- unindented XML tags in pom.xml
- unused fields in LibratoWriter
- too generic exception catch in LibratoWriter

The two last points made the `mvn verify` command fail because of
findbugs.  This patch fixes the issues.