### PR TITLE
UDP output writer for Graphite

### DIFF
--- a/src/main/java/org/jmxtrans/agent/GraphiteUdpOutputWriter.java
+++ b/src/main/java/org/jmxtrans/agent/GraphiteUdpOutputWriter.java
@@ -1,0 +1,181 @@
+/*
+ * Copyright (c) 2010-2013 the original author or authors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+ * LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ */
+package org.jmxtrans.agent;
+
+import static org.jmxtrans.agent.util.ConfigurationUtils.*;
+
+import java.io.IOException;
+import java.net.DatagramPacket;
+import java.net.DatagramSocket;
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.net.SocketException;
+import java.net.UnknownHostException;
+import java.nio.charset.Charset;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+import java.util.logging.Level;
+
+import org.jmxtrans.agent.util.net.HostAndPort;
+
+/**
+ * Output writer for writing to Graphite using UDP.
+ * 
+ * @author Kristoffer Erlandsson
+ */
+public class GraphiteUdpOutputWriter extends AbstractOutputWriter {
+
+    final static Charset CHARSET_FOR_UDP_PACKET = Charset.forName("UTF-8");
+    private final static String SETTING_HOST = "host";
+    private final static String SETTING_PORT = "port";
+    private static final int SETTING_PORT_DEFAULT_VALUE = 2003;
+    private final static String SETTING_NAME_PREFIX = "namePrefix";
+    private HostAndPort graphiteServerHostAndPort;
+    private String metricPathPrefix;
+    private UdpMessageSender messageSender;
+    private Clock clock;
+
+    @Override
+    public void postConstruct(Map<String, String> settings) {
+        super.postConstruct(settings);
+        graphiteServerHostAndPort = new HostAndPort(
+                getString(settings, SETTING_HOST),
+                getInt(settings, SETTING_PORT, SETTING_PORT_DEFAULT_VALUE));
+        metricPathPrefix = getString(settings, SETTING_NAME_PREFIX, null);
+        messageSender = new UdpMessageSender(graphiteServerHostAndPort);
+        clock = new SystemCurrentTimeMillisClock();
+        logger.log(getInfoLevel(), "GraphiteUdpOutputWriter is configured with " + graphiteServerHostAndPort
+                + ", metricPathPrefix=" + metricPathPrefix);
+    }
+
+    @Override
+    public void writeInvocationResult(String invocationName, Object value) throws IOException {
+        writeQueryResult(invocationName, null, value);
+    }
+
+    @Override
+    public void writeQueryResult(String metricName, String metricType, Object value) throws IOException {
+        String msg = buildMetricPathPrefix() + metricName + " " + value + " " + clock.getCurrentInTimeSeconds() + "\n";
+        logMessageIfTraceLoggable(msg);
+        tryWriteMsg(msg);
+    }
+
+    /**
+     * {@link java.net.InetAddress#getLocalHost()} may not be known at JVM startup when the process is launched as a
+     * Linux service.
+     *
+     * @return
+     */
+    protected String buildMetricPathPrefix() {
+        if (metricPathPrefix != null) {
+            return metricPathPrefix;
+        }
+        String hostname;
+        try {
+            hostname = InetAddress.getLocalHost().getHostName().replaceAll("\\.", "_");
+        } catch (UnknownHostException e) {
+            hostname = "#unknown#";
+        }
+        metricPathPrefix = "servers." + hostname + ".";
+        return metricPathPrefix;
+    }
+
+    private void logMessageIfTraceLoggable(String msg) {
+        if (logger.isLoggable(getTraceLevel())) {
+            logger.log(getTraceLevel(), "Send '" + msg + "' to " + graphiteServerHostAndPort);
+        }
+    }
+
+    private void tryWriteMsg(String msg) throws IOException {
+        try {
+            messageSender.send(msg);
+        } catch (IOException e) {
+            logger.log(Level.WARNING, "Exception sending '" + msg + "' to " + graphiteServerHostAndPort, e);
+            throw e;
+        }
+    }
+
+    @Override
+    public void preDestroy() {
+        super.preDestroy();
+        if (messageSender != null) {
+            messageSender.close();
+        }
+    }
+
+    @Override
+    public String toString() {
+        return "GraphiteUdpOutputWriter{" +
+                ", " + graphiteServerHostAndPort +
+                ", metricPathPrefix='" + metricPathPrefix + "'" +
+                "}";
+    }
+
+    /** Test hook */
+    void setClock(Clock clock) {
+        this.clock = clock;
+    }
+
+    private static class UdpMessageSender {
+
+        private final DatagramSocket clientSocket;
+        private final HostAndPort hostAndPort;
+
+        public UdpMessageSender(HostAndPort hostAndPort) {
+            this.hostAndPort = hostAndPort;
+            try {
+                clientSocket = new DatagramSocket();
+            } catch (SocketException e) {
+                throw new RuntimeException("Failed to create DatagramSocket", e);
+            }
+        }
+
+        public void send(String msg) throws IOException {
+            DatagramPacket packetToSend = createUdpPacket(msg);
+            clientSocket.send(packetToSend);
+        }
+
+        private DatagramPacket createUdpPacket(String msg) throws SocketException {
+            byte[] messageBytes = msg.getBytes(CHARSET_FOR_UDP_PACKET);
+            InetSocketAddress adress = new InetSocketAddress(hostAndPort.getHost(), hostAndPort.getPort());
+            return new DatagramPacket(messageBytes, messageBytes.length, adress);
+        }
+
+        public void close() {
+            clientSocket.close();
+        }
+    }
+
+    interface Clock {
+        long getCurrentInTimeSeconds();
+    }
+
+    private static class SystemCurrentTimeMillisClock implements Clock {
+
+        @Override
+        public long getCurrentInTimeSeconds() {
+            return TimeUnit.SECONDS.convert(System.currentTimeMillis(), TimeUnit.MILLISECONDS);
+        }
+    }
+}

--- a/src/test/java/org/jmxtrans/agent/GraphiteUdpOutputWriterTest.java
+++ b/src/test/java/org/jmxtrans/agent/GraphiteUdpOutputWriterTest.java
@@ -1,0 +1,192 @@
+/*
+ * Copyright (c) 2010-2013 the original author or authors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+ * LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ */
+package org.jmxtrans.agent;
+
+import static org.hamcrest.Matchers.*;
+import static org.junit.Assert.*;
+
+import java.io.IOException;
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.nio.ByteBuffer;
+import java.nio.channels.DatagramChannel;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.hamcrest.Matcher;
+import org.jmxtrans.agent.GraphiteUdpOutputWriter.Clock;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TestRule;
+import org.junit.runner.Description;
+import org.junit.runners.model.Statement;
+
+/**
+ * Tests for GraphiteUdpOutputWriter.
+ * 
+ * @author Kristoffer Erlandsson
+ */
+public class GraphiteUdpOutputWriterTest {
+
+    @Rule
+    public UdpServer udpServer = new UdpServer();
+
+    private Clock clock = new FakeClock(1111);
+
+    private GraphiteUdpOutputWriter writer;
+
+    @Before
+    public void createWriter() throws Exception {
+        writer = new GraphiteUdpOutputWriter();
+        writer.postConstruct(testSettings());
+        writer.setClock(clock);
+    }
+
+    @Test
+    public void oneQueryResult() throws Exception {
+        writer.writeQueryResult("metric", "type", 1);
+        assertEventuallyReceived(udpServer, contains("foo.metric 1 1111\n"));
+    }
+
+    @Test
+    public void manyQueryResults() throws Exception {
+        writer.writeQueryResult("metric", "type", 1);
+        writer.writeQueryResult("metric.2", "type", 2);
+        writer.writeQueryResult("metric.3", "type", 3);
+        assertEventuallyReceived(udpServer,
+                containsInAnyOrder("foo.metric 1 1111\n", "foo.metric.2 2 1111\n", "foo.metric.3 3 1111\n"));
+    }
+
+    @Test
+    public void oneInvocationResult() throws Exception {
+        writer.writeInvocationResult("invoke", 123);
+        assertEventuallyReceived(udpServer, contains("foo.invoke 123 1111\n"));
+    }
+
+    @After
+    public void destroyWriter() {
+        writer.preDestroy();
+    }
+
+    private Map<String, String> testSettings() throws IOException {
+        Map<String, String> settings = new HashMap<>();
+        settings.put("host", "127.0.0.1");
+        settings.put("port", "" + udpServer.getPort());
+        settings.put("namePrefix", "foo.");
+        return settings;
+    }
+
+    /**
+     * Waits for one second for the received messages of the UdpServer to match the matcher.
+     */
+    public void assertEventuallyReceived(UdpServer server, Matcher<Iterable<? extends String>> matcher)
+            throws Exception {
+        for (int i = 0; i < 100; i++) {
+            server.receiveAvailableDatagrams();
+            if (matcher.matches(server.getReceivedMessages())) {
+                return;
+            }
+            Thread.sleep(10);
+        }
+        assertThat(server.getReceivedMessages(), matcher);
+    }
+
+    private static class FakeClock implements Clock {
+
+        private final long constantTime;
+
+        public FakeClock(long constantTime) {
+            this.constantTime = constantTime;
+        }
+
+        @Override
+        public long getCurrentInTimeSeconds() {
+            return constantTime;
+        }
+
+    }
+
+    private static class UdpServer implements TestRule {
+
+        private List<String> receivedMessages = new ArrayList<>();
+        private DatagramChannel channel;
+
+        public void openChannel() throws Exception {
+            channel = DatagramChannel.open();
+            channel.bind(new InetSocketAddress(InetAddress.getLoopbackAddress(), 0));
+            channel.configureBlocking(false);
+        }
+
+        private void closeChannelAndClearMessages() throws IOException {
+            if (channel != null) {
+                channel.close();
+            }
+            receivedMessages.clear();
+        }
+
+        public List<String> getReceivedMessages() {
+            return receivedMessages;
+        }
+
+        public int getPort() throws IOException {
+            return ((InetSocketAddress) channel.getLocalAddress()).getPort();
+        }
+
+        public void receiveAvailableDatagrams() throws IOException {
+            while (true) {
+                ByteBuffer buffer = ByteBuffer.allocate(1024);
+                if (channel.receive(buffer) == null) {
+                    break;
+                }
+                buffer.flip();
+                byte[] bytes = new byte[buffer.remaining()];
+                buffer.get(bytes);
+                String result = new String(bytes, GraphiteUdpOutputWriter.CHARSET_FOR_UDP_PACKET);
+                receivedMessages.add(result);
+            }
+        }
+
+        @Override
+        public Statement apply(final Statement base, Description description) {
+            return new Statement() {
+
+                @Override
+                public void evaluate() throws Throwable {
+                    try {
+                        openChannel();
+                        base.evaluate();
+                    } finally {
+                        closeChannelAndClearMessages();
+                    }
+                }
+
+            };
+        }
+
+    }
+}


### PR DESCRIPTION
Implementation of an output writer for Graphite that uses UDP.

There is currently some code duplication with the `GraphitePlainTextTcpOutputWriter`, especially in `buildMetricPathPrefix` and in the configuration key constants. If you accept this PR I can put in some work towards reusing the common parts between the implementations.

Any feedback you have is welcome.