### PR TITLE
Refactoring of Graphite output writers

### DIFF
--- a/src/main/java/org/jmxtrans/agent/graphite/GraphiteMetricMessageBuilder.java
+++ b/src/main/java/org/jmxtrans/agent/graphite/GraphiteMetricMessageBuilder.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) 2010-2013 the original author or authors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+ * LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ */
+package org.jmxtrans.agent.graphite;
+
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+
+import javax.annotation.Nullable;
+
+/**
+ * Generates metric messages to send to graphite instances.
+ */
+public class GraphiteMetricMessageBuilder {
+
+    private static final String DEFAULT_METRIC_PATH_PREFIX_FORMAT = "servers.%s.";
+    private final String metricPathPrefix;
+    
+    /**
+     * @param configuredMetricPathPrefix
+     *            Prefix to add to the metric keys. May be null, in which case servers.your_hostname will be used.
+     */
+    public GraphiteMetricMessageBuilder(@Nullable String configuredMetricPathPrefix) {
+        this.metricPathPrefix = buildMetricPathPrefix(configuredMetricPathPrefix);
+    } 
+    
+    /**
+     * Builds a metric string to send to a Graphite instance.
+     * 
+     * @return The metric string without trailing newline
+     */
+    public String buildMessage(String metricName, Object value, long timestamp) {
+        return metricPathPrefix + metricName + " " + value + " " + timestamp;
+    }
+    
+    /**
+     * {@link java.net.InetAddress#getLocalHost()} may not be known at JVM startup when the process is launched as a Linux service.
+     */
+    private static String buildMetricPathPrefix(String configuredMetricPathPrefix) {
+        if (configuredMetricPathPrefix != null) {
+            return configuredMetricPathPrefix;
+        }
+        String hostname;
+        try {
+            hostname = InetAddress.getLocalHost().getHostName().replaceAll("\\.", "_");
+        } catch (UnknownHostException e) {
+            hostname = "#unknown#";
+        }
+        return String.format(DEFAULT_METRIC_PATH_PREFIX_FORMAT, hostname);
+    }
+    
+    public String getPrefix() {
+        return metricPathPrefix;
+    }
+        
+}

--- a/src/main/java/org/jmxtrans/agent/graphite/GraphiteOutputWriterCommonSettings.java
+++ b/src/main/java/org/jmxtrans/agent/graphite/GraphiteOutputWriterCommonSettings.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2010-2013 the original author or authors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+ * LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ */
+package org.jmxtrans.agent.graphite;
+
+import static org.jmxtrans.agent.util.ConfigurationUtils.*;
+
+import java.util.Map;
+
+import org.jmxtrans.agent.util.net.HostAndPort;
+
+/**
+ * Setting keys and default values common for Graphite Output writers.
+ */
+public class GraphiteOutputWriterCommonSettings {
+
+    public static final String SETTING_HOST = "host";
+    public static final String SETTING_PORT = "port";
+    public static final int SETTING_PORT_DEFAULT_VALUE = 2003;
+    public static final String SETTING_NAME_PREFIX = "namePrefix";
+    
+    public static HostAndPort getHostAndPort(Map<String, String> settings) {
+        return new HostAndPort(getString(settings, SETTING_HOST),
+                getInt(settings, SETTING_PORT, SETTING_PORT_DEFAULT_VALUE));
+    }
+    
+    public static String getConfiguredMetricPrefixOrNull(Map<String, String> settings) {
+        return getString(settings, SETTING_NAME_PREFIX, null);
+    }
+}

--- a/src/test/java/org/jmxtrans/agent/GraphiteMetricMessageBuilderTest.java
+++ b/src/test/java/org/jmxtrans/agent/GraphiteMetricMessageBuilderTest.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2010-2013 the original author or authors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+ * LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ */
+package org.jmxtrans.agent;
+
+import static org.hamcrest.Matchers.*;
+import static org.junit.Assert.*;
+
+import org.jmxtrans.agent.graphite.GraphiteMetricMessageBuilder;
+import org.junit.Test;
+
+/**
+ * @author Kristoffer Erlandsson
+ */
+public class GraphiteMetricMessageBuilderTest {
+
+    @Test
+    public void configuredPrefix() throws Exception {
+        GraphiteMetricMessageBuilder builder = new GraphiteMetricMessageBuilder("foo.");
+        String msg = builder.buildMessage("bar", 2, 11);
+        assertThat(msg, equalTo("foo.bar 2 11"));
+    }
+
+    @Test
+    public void defaultPrefix() throws Exception {
+        GraphiteMetricMessageBuilder builder = new GraphiteMetricMessageBuilder(null);
+        String msg = builder.buildMessage("bar", 2, 11);
+        assertThat(msg, startsWith("servers."));
+        assertThat(msg, endsWith(" 2 11"));
+    }
+
+}

--- a/src/test/java/org/jmxtrans/agent/JmxTransExporterBuilderTest.java
+++ b/src/test/java/org/jmxtrans/agent/JmxTransExporterBuilderTest.java
@@ -57,7 +57,7 @@ public class JmxTransExporterBuilderTest {
         GraphitePlainTextTcpOutputWriter graphiteWriter = (GraphitePlainTextTcpOutputWriter) circuitBreakerDecorator.delegate;
         assertThat(graphiteWriter.graphiteServerHostAndPort.getPort(), is(2203));
         assertThat(graphiteWriter.graphiteServerHostAndPort.getHost(), is("localhost"));
-        assertThat(graphiteWriter.metricPathPrefix, is("app_123456.server.i876543."));
+        assertThat(graphiteWriter.getMetricPathPrefix(), is("app_123456.server.i876543."));
 
         assertThat(jmxTransExporter.queries.size(), is(13));
 
@@ -111,7 +111,7 @@ public class JmxTransExporterBuilderTest {
             GraphitePlainTextTcpOutputWriter writer = (GraphitePlainTextTcpOutputWriter) circuitBreakerDecorator.delegate;
             assertThat(writer.graphiteServerHostAndPort.getPort(), is(2003));
             assertThat(writer.graphiteServerHostAndPort.getHost(), is("localhost"));
-            assertThat(writer.metricPathPrefix, is("servers.localhost."));
+            assertThat(writer.getMetricPathPrefix(), is("servers.localhost."));
         }
         {
             OutputWriter decoratedOutputWriter = outputWritersChain.outputWriters.get(1);


### PR DESCRIPTION
I have made some refactoring to the Graphite output writers to reuse the code common to both the TCP and UDP implementation. I felt there was a bit too much duplication after me adding the UDP variant.

* Created `GraphiteMetricMessageBuilder` responsible for generating the actual message, including optionally generating the default prefix.
* Created `GraphiteOutputWriterCommonSettings` to keep setting constants common to both implementation and convenient accessors to the settings.
* Test for `GraphiteMetricMessageBuilder`

Please let me know any feedback you have.

And thank you for the swift handling of my previous work!