### PR TITLE
Support for comma separated list of attributes in a query

### DIFF
--- a/src/main/java/org/jmxtrans/agent/JmxTransExporter.java
+++ b/src/main/java/org/jmxtrans/agent/JmxTransExporter.java
@@ -71,13 +71,13 @@ public class JmxTransExporter {
     private MBeanServer mbeanServer = ManagementFactory.getPlatformMBeanServer();
     private ScheduledFuture scheduledFuture;
 
-    public JmxTransExporter withQuery(@Nonnull String objectName, @Nonnull String attribute, @Nullable String resultAlias) {
-        return withQuery(objectName, attribute, null, null, null, resultAlias);
+    public JmxTransExporter withQuery(@Nonnull String objectName, @Nonnull List<String> attributes, @Nullable String resultAlias) {
+        return withQuery(objectName, attributes, null, null, null, resultAlias);
     }
 
-    public JmxTransExporter withQuery(@Nonnull String objectName, @Nonnull String attribute, @Nullable String key,
+    public JmxTransExporter withQuery(@Nonnull String objectName, @Nonnull List<String> attributes, @Nullable String key,
                                       @Nullable Integer position, @Nullable String type, @Nullable String resultAlias) {
-        Query query = new Query(objectName, attribute, key, position, type, resultAlias, this.resultNameStrategy);
+        Query query = new Query(objectName, attributes, key, position, type, resultAlias, this.resultNameStrategy);
         queries.add(query);
         return this;
     }

--- a/src/main/java/org/jmxtrans/agent/JmxTransExporterBuilder.java
+++ b/src/main/java/org/jmxtrans/agent/JmxTransExporterBuilder.java
@@ -35,10 +35,13 @@ import java.io.File;
 import java.io.InputStream;
 import java.net.URL;
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
+import java.util.regex.Pattern;
 
 /**
  * XML configuration parser.
@@ -47,6 +50,7 @@ import java.util.concurrent.TimeUnit;
  */
 public class JmxTransExporterBuilder {
 
+    private static final Pattern ATTRIBUTE_SPLIT_PATTERN = Pattern.compile("\\s*,\\s*");
     private Logger logger = Logger.getLogger(getClass().getName());
     private PropertyPlaceholderResolver placeholderResolver = new PropertyPlaceholderResolver();
 
@@ -120,7 +124,7 @@ public class JmxTransExporterBuilder {
         for (int i = 0; i < queries.getLength(); i++) {
             Element queryElement = (Element) queries.item(i);
             String objectName = queryElement.getAttribute("objectName");
-            String attribute = queryElement.getAttribute("attribute");
+            List<String> attributes = getAttributes(queryElement, objectName);
             String key = queryElement.hasAttribute("key") ? queryElement.getAttribute("key") : null;
             String resultAlias = queryElement.getAttribute("resultAlias");
             String type = queryElement.getAttribute("type");
@@ -129,11 +133,30 @@ public class JmxTransExporterBuilder {
                 position = queryElement.hasAttribute("position") ? Integer.parseInt(queryElement.getAttribute("position")) : null;
             } catch (NumberFormatException e) {
                 throw new IllegalArgumentException("Invalid 'position' attribute for query objectName=" + objectName +
-                        ", attribute=" + attribute + ", resultAlias=" + resultAlias);
+                        ", attributes=" + attributes + ", resultAlias=" + resultAlias);
 
             }
 
-            jmxTransExporter.withQuery(objectName, attribute, key, position, type, resultAlias);
+            jmxTransExporter.withQuery(objectName, attributes, key, position, type, resultAlias);
+        }
+    }
+
+    private List<String> getAttributes(Element queryElement, String objectName) {
+        String attribute = queryElement.getAttribute("attribute");
+        String attributes = queryElement.getAttribute("attributes");
+        validateOnlyAttributeOrAttributesSpecified(attribute, attributes, objectName);
+        if (!attribute.isEmpty()) {
+            return Collections.singletonList(attribute);
+        } else {
+           String[] splitAttributes = ATTRIBUTE_SPLIT_PATTERN.split(attributes);
+           return Arrays.asList(splitAttributes);
+        }
+    }
+
+
+    private void validateOnlyAttributeOrAttributesSpecified(String attribute, String attributes, String objectName) {
+        if (!attribute.isEmpty() && !attributes.isEmpty()) {
+            throw new IllegalArgumentException("Only one of 'attribute' and 'attributes' is supported for a query - not both - objectName: " + objectName);
         }
     }
 

--- a/src/main/java/org/jmxtrans/agent/JmxTransExporterBuilder.java
+++ b/src/main/java/org/jmxtrans/agent/JmxTransExporterBuilder.java
@@ -145,6 +145,9 @@ public class JmxTransExporterBuilder {
         String attribute = queryElement.getAttribute("attribute");
         String attributes = queryElement.getAttribute("attributes");
         validateOnlyAttributeOrAttributesSpecified(attribute, attributes, objectName);
+        if (attribute.isEmpty() && attributes.isEmpty()) {
+            return Collections.emptyList();
+        }
         if (!attribute.isEmpty()) {
             return Collections.singletonList(attribute);
         } else {

--- a/src/main/java/org/jmxtrans/agent/Query.java
+++ b/src/main/java/org/jmxtrans/agent/Query.java
@@ -50,13 +50,15 @@ public class Query {
     @Nonnull
     protected final ObjectName objectName;
 
+    /**
+     * The attribute(s) to retrieve ({@link MBeanServer#getAttribute(javax.management.ObjectName, String)})
+     * 
+     * If empty, will fetch all attributes of the MBean.
+     */
+    @Nonnull
+    protected List<String> attributes;
     @Nullable
     protected final String resultAlias;
-    /**
-     * The attribute to retrieve ({@link MBeanServer#getAttribute(javax.management.ObjectName, String)})
-     */
-    @Nullable
-    protected final String attribute;
     /**
      * If the MBean attribute value is a {@link CompositeData}, the key to lookup.
      *
@@ -69,6 +71,8 @@ public class Query {
      */
     @Nullable
     protected final Integer position;
+
+
     /**
      * Attribute type like '{@code gauge}' or '{@code counter}'. Used by monitoring systems like Librato who require this information.
      */
@@ -110,18 +114,34 @@ public class Query {
      */
     public Query(@Nonnull String objectName, @Nullable String attribute, @Nullable String key, @Nullable Integer position,
                  @Nullable String type, @Nullable String resultAlias, @Nonnull ResultNameStrategy resultNameStrategy) {
+        this(objectName, nullOrEmtpy(attribute) ? Collections.<String>emptyList() : Collections.singletonList(attribute), key, position,
+                type, resultAlias, resultNameStrategy);
+    }
+
+    private static boolean nullOrEmtpy(String attribute) {
+        return attribute == null || attribute.isEmpty();
+    }
+    
+    /**
+     * Creates a query that accepts a list of attributes to collect. If the list is empty, all attributes will be collected.
+     * 
+     * @see #Query(String, String, String, Integer, String, String, ResultNameStrategy)
+     */
+    public Query(@Nonnull String objectName, @Nonnull List<String> attributes, @Nullable String key, @Nullable Integer position,
+            @Nullable String type, @Nullable String resultAlias, @Nonnull ResultNameStrategy resultNameStrategy) {
         try {
             this.objectName = new ObjectName(Preconditions2.checkNotNull(objectName));
         } catch (MalformedObjectNameException e) {
             throw new IllegalArgumentException("Invalid objectName '" + objectName + "'", e);
         }
-        this.attribute = attribute;
+        this.attributes = Collections.unmodifiableList(new ArrayList<String>(Preconditions2.checkNotNull(attributes, "attributes")));
         this.key = key;
         this.resultAlias = resultAlias;
         this.position = position;
         this.type = type;
         this.resultNameStrategy = Preconditions2.checkNotNull(resultNameStrategy, "resultNameStrategy");
     }
+
 
     public void collectAndExport(@Nonnull MBeanServer mbeanServer, @Nonnull OutputWriter outputWriter) {
         if (resultNameStrategy == null)
@@ -130,32 +150,33 @@ public class Query {
         Set<ObjectName> objectNames = mbeanServer.queryNames(objectName, null);
 
         for (ObjectName on : objectNames) {
-            try {
-                collectAndExportForObjectName(mbeanServer, on, outputWriter);
-            } catch (Exception e) {
-                logger.log(Level.WARNING, "Exception collecting " + on + "#" + attribute + (key == null ? "" : "#" + key), e);
-            }
+            collectAndExportForObjectName(mbeanServer, outputWriter, on);
         }
     }
 
-    private void collectAndExportForObjectName(MBeanServer mbeanServer, ObjectName on, OutputWriter outputWriter)
-            throws Exception {
+    private void collectAndExportForObjectName(MBeanServer mbeanServer, OutputWriter outputWriter, ObjectName on) {
         for (String attribute : resolveAttributes(mbeanServer, on)) {
-                collectAndExportAttribute(mbeanServer, outputWriter, on, attribute);
+            collectAndExportAttribute(mbeanServer, outputWriter, on, attribute);
         }
     }
 
-    private List<String> resolveAttributes(MBeanServer mbeanServer, ObjectName on) throws Exception {
+
+    private List<String> resolveAttributes(MBeanServer mbeanServer, ObjectName on) {
+        if (attributes.isEmpty()) {
+            return findAllAttributes(mbeanServer, on);
+        }
+        return attributes;
+    }
+
+    private List<String> findAllAttributes(MBeanServer mbeanServer, ObjectName on) {
         List<String> resolvedAttributes = new ArrayList<>();
-        if (attribute == null || attribute.isEmpty()) {
-            // Null or empty attribute specified, collect all attributes
+        // Null or empty attribute specified, collect all attributes
+        try {
             for (MBeanAttributeInfo mBeanAttributeInfo : mbeanServer.getMBeanInfo(on).getAttributes()) {
                 resolvedAttributes.add(mBeanAttributeInfo.getName());
             }
-        } else {
-           // Single attribute or comma-separated list specified, collect specified attribute(s).
-           String[]  attributes = attribute.split(",");
-           resolvedAttributes.addAll(Arrays.asList(attributes));
+        } catch (IntrospectionException | InstanceNotFoundException | ReflectionException e) {
+            logger.log(Level.WARNING, "Error when finding attributes for ObjectName " + on + ", all attributes will not be collected", e);
         }
         return resolvedAttributes;
     }
@@ -245,7 +266,7 @@ public class Query {
         return "Query{" +
                 "objectName=" + objectName +
                 ", resultAlias='" + resultAlias + '\'' +
-                ", attribute='" + attribute + '\'' +
+                ", attributes='" + attributes + '\'' +
                 ", key='" + key + '\'' +
                 '}';
     }
@@ -261,8 +282,8 @@ public class Query {
     }
 
     @Nullable
-    public String getAttribute() {
-        return attribute;
+    public List<String> getAttributes() {
+        return attributes;
     }
 
     @Nullable

--- a/src/test/java/org/jmxtrans/agent/JmxTransExporterBuilderTest.java
+++ b/src/test/java/org/jmxtrans/agent/JmxTransExporterBuilderTest.java
@@ -154,6 +154,15 @@ public class JmxTransExporterBuilderTest {
         assertThat(query.getAttributes(), contains("ThreadCount", "TotalStartedThreadCount"));
     }
 
+    @Test
+    public void testNoAttributesSpecifiedGeneratesWildcardQuery() throws Exception {
+        JmxTransExporterBuilder builder = new JmxTransExporterBuilder();
+        JmxTransExporter jmxTransExporter = builder.build("classpath:jmxtrans-no-attributes-specified-generates-wildcard-query-test.xml");
+        assertThat(jmxTransExporter.queries, hasSize(1));
+        Query query = jmxTransExporter.queries.get(0);
+        assertThat(query.getAttributes(), emptyIterable());
+    }
+
     @Test(expected=IllegalArgumentException.class)
     public void testParseConfigurationAttributeAndAttributesMutuallyExclusive() throws Exception {
         JmxTransExporterBuilder builder = new JmxTransExporterBuilder();

--- a/src/test/java/org/jmxtrans/agent/JmxTransExporterBuilderTest.java
+++ b/src/test/java/org/jmxtrans/agent/JmxTransExporterBuilderTest.java
@@ -66,14 +66,14 @@ public class JmxTransExporterBuilderTest {
         {
             Query query = queriesByResultAlias.get("os.systemLoadAverage");
             assertThat(query.objectName, is(new ObjectName("java.lang:type=OperatingSystem")));
-            assertThat(query.attribute, is("SystemLoadAverage"));
+            assertThat(query.getAttributes(), contains("SystemLoadAverage"));
             assertThat(query.resultAlias, is("os.systemLoadAverage"));
             assertThat(query.key, is((String) null));
         }
         {
             Query query = queriesByResultAlias.get("jvm.heapMemoryUsage.used");
             assertThat(query.objectName, is(new ObjectName("java.lang:type=Memory")));
-            assertThat(query.attribute, is("HeapMemoryUsage"));
+            assertThat(query.getAttributes(), contains("HeapMemoryUsage"));
             assertThat(query.resultAlias, is("jvm.heapMemoryUsage.used"));
             assertThat(query.key, is("used"));
         }
@@ -132,17 +132,32 @@ public class JmxTransExporterBuilderTest {
         {
             Query query = queriesByResultAlias.get("os.systemLoadAverage");
             assertThat(query.objectName, is(new ObjectName("java.lang:type=OperatingSystem")));
-            assertThat(query.attribute, is("SystemLoadAverage"));
+            assertThat(query.getAttributes(), contains("SystemLoadAverage"));
             assertThat(query.resultAlias, is("os.systemLoadAverage"));
             assertThat(query.key, is((String) null));
         }
         {
             Query query = queriesByResultAlias.get("jvm.heapMemoryUsage.used");
             assertThat(query.objectName, is(new ObjectName("java.lang:type=Memory")));
-            assertThat(query.attribute, is("HeapMemoryUsage"));
+            assertThat(query.getAttributes(), contains("HeapMemoryUsage"));
             assertThat(query.resultAlias, is("jvm.heapMemoryUsage.used"));
             assertThat(query.key, is("used"));
         }
+    }
+
+    @Test
+    public void testParseConfigurationMultipleAttributes() throws Exception {
+        JmxTransExporterBuilder builder = new JmxTransExporterBuilder();
+        JmxTransExporter jmxTransExporter = builder.build("classpath:jmxtrans-multiple-attributes-test.xml");
+        assertThat(jmxTransExporter.queries, hasSize(1));
+        Query query = jmxTransExporter.queries.get(0);
+        assertThat(query.getAttributes(), contains("ThreadCount", "TotalStartedThreadCount"));
+    }
+
+    @Test(expected=IllegalArgumentException.class)
+    public void testParseConfigurationAttributeAndAttributesMutuallyExclusive() throws Exception {
+        JmxTransExporterBuilder builder = new JmxTransExporterBuilder();
+        builder.build("classpath:jmxtrans-attribute-attributes-exclusive-test.xml");
     }
 
     Map<String, Query> indexQueriesByResultAlias(Iterable<Query> queries) {

--- a/src/test/java/org/jmxtrans/agent/QueryTest.java
+++ b/src/test/java/org/jmxtrans/agent/QueryTest.java
@@ -192,6 +192,21 @@ public class QueryTest {
         assert (actualSize == 24);
     }
 
+    @Test
+    public void comma_separted_attribute_returns_specified_attributes() throws Exception {
+        Query query = new Query("test:type=Mock,name=mock", "CollectionUsageThreshold,Name", "altTest.#attribute#", resultNameStrategy);
+        query.collectAndExport(mbeanServer, mockOutputWriter);
+        assertThat(mockOutputWriter.resultsByName.get("altTest.Name"), notNullValue());
+        assertThat(mockOutputWriter.resultsByName.get("altTest.CollectionUsageThreshold"), notNullValue());
+    }
+
+    @Test
+    public void comma_separted_attribute_does_not_return_not_specified_attribute() throws Exception {
+        Query query = new Query("test:type=Mock,name=mock", "CollectionUsageThreshold,Name", "altTest.#attribute#", resultNameStrategy);
+        query.collectAndExport(mbeanServer, mockOutputWriter);
+        assertThat(mockOutputWriter.resultsByName.get("CollectionUsageThreshold"), nullValue());
+    }
+
     public static class MockOutputWriter extends AbstractOutputWriter {
 
         protected final boolean failOnDuplicateResult;

--- a/src/test/java/org/jmxtrans/agent/QueryTest.java
+++ b/src/test/java/org/jmxtrans/agent/QueryTest.java
@@ -31,6 +31,7 @@ import javax.management.MBeanServer;
 import javax.management.ObjectName;
 import java.io.IOException;
 import java.lang.management.ManagementFactory;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -193,16 +194,18 @@ public class QueryTest {
     }
 
     @Test
-    public void comma_separted_attribute_returns_specified_attributes() throws Exception {
-        Query query = new Query("test:type=Mock,name=mock", "CollectionUsageThreshold,Name", "altTest.#attribute#", resultNameStrategy);
+    public void attribute_list_returns_specified_attributes() throws Exception {
+        Query query = new Query("test:type=Mock,name=mock", Arrays.asList("CollectionUsageThreshold", "Name"), null,
+                null, null, "altTest.#attribute#", resultNameStrategy);
         query.collectAndExport(mbeanServer, mockOutputWriter);
         assertThat(mockOutputWriter.resultsByName.get("altTest.Name"), notNullValue());
         assertThat(mockOutputWriter.resultsByName.get("altTest.CollectionUsageThreshold"), notNullValue());
     }
 
     @Test
-    public void comma_separted_attribute_does_not_return_not_specified_attribute() throws Exception {
-        Query query = new Query("test:type=Mock,name=mock", "CollectionUsageThreshold,Name", "altTest.#attribute#", resultNameStrategy);
+    public void attribute_list_attribute_does_not_return_not_specified_attribute() throws Exception {
+        Query query = new Query("test:type=Mock,name=mock", Arrays.asList("CollectionUsageThreshold", "Name"), null,
+                null, null, "altTest.#attribute#", resultNameStrategy);
         query.collectAndExport(mbeanServer, mockOutputWriter);
         assertThat(mockOutputWriter.resultsByName.get("CollectionUsageThreshold"), nullValue());
     }

--- a/src/test/resources/jmxtrans-attribute-attributes-exclusive-test.xml
+++ b/src/test/resources/jmxtrans-attribute-attributes-exclusive-test.xml
@@ -1,0 +1,30 @@
+<!--
+ ~ Copyright (c) 2010-2013 the original author or authors
+ ~
+ ~ Permission is hereby granted, free of charge, to any person obtaining
+ ~ a copy of this software and associated documentation files (the
+ ~ "Software"), to deal in the Software without restriction, including
+ ~ without limitation the rights to use, copy, modify, merge, publish,
+ ~ distribute, sublicense, and/or sell copies of the Software, and to
+ ~ permit persons to whom the Software is furnished to do so, subject to
+ ~ the following conditions:
+ ~
+ ~ The above copyright notice and this permission notice shall be
+ ~ included in all copies or substantial portions of the Software.
+ ~
+ ~ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ ~ EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ ~ MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ ~ NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+ ~ LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ ~ OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ ~ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ ~
+-->
+<jmxtrans-agent>
+    <queries>
+        <query objectName="java.lang:type=Threading" attribute="foo" attributes="ThreadCount ,	TotalStartedThreadCount" resultAlias="jvm.thread"/>
+    </queries>
+    <outputWriter class="org.jmxtrans.agent.ConsoleOutputWriter" />
+    <collectIntervalInSeconds>11</collectIntervalInSeconds>
+</jmxtrans-agent>

--- a/src/test/resources/jmxtrans-multiple-attributes-test.xml
+++ b/src/test/resources/jmxtrans-multiple-attributes-test.xml
@@ -1,0 +1,30 @@
+<!--
+ ~ Copyright (c) 2010-2013 the original author or authors
+ ~
+ ~ Permission is hereby granted, free of charge, to any person obtaining
+ ~ a copy of this software and associated documentation files (the
+ ~ "Software"), to deal in the Software without restriction, including
+ ~ without limitation the rights to use, copy, modify, merge, publish,
+ ~ distribute, sublicense, and/or sell copies of the Software, and to
+ ~ permit persons to whom the Software is furnished to do so, subject to
+ ~ the following conditions:
+ ~
+ ~ The above copyright notice and this permission notice shall be
+ ~ included in all copies or substantial portions of the Software.
+ ~
+ ~ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ ~ EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ ~ MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ ~ NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+ ~ LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ ~ OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ ~ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ ~
+-->
+<jmxtrans-agent>
+    <queries>
+        <query objectName="java.lang:type=Threading" attributes="ThreadCount ,	TotalStartedThreadCount" resultAlias="jvm.thread"/>
+    </queries>
+    <outputWriter class="org.jmxtrans.agent.ConsoleOutputWriter" />
+    <collectIntervalInSeconds>11</collectIntervalInSeconds>
+</jmxtrans-agent>

--- a/src/test/resources/jmxtrans-no-attributes-specified-generates-wildcard-query-test.xml
+++ b/src/test/resources/jmxtrans-no-attributes-specified-generates-wildcard-query-test.xml
@@ -1,0 +1,30 @@
+<!--
+ ~ Copyright (c) 2010-2013 the original author or authors
+ ~
+ ~ Permission is hereby granted, free of charge, to any person obtaining
+ ~ a copy of this software and associated documentation files (the
+ ~ "Software"), to deal in the Software without restriction, including
+ ~ without limitation the rights to use, copy, modify, merge, publish,
+ ~ distribute, sublicense, and/or sell copies of the Software, and to
+ ~ permit persons to whom the Software is furnished to do so, subject to
+ ~ the following conditions:
+ ~
+ ~ The above copyright notice and this permission notice shall be
+ ~ included in all copies or substantial portions of the Software.
+ ~
+ ~ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ ~ EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ ~ MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ ~ NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+ ~ LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ ~ OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ ~ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ ~
+-->
+<jmxtrans-agent>
+    <queries>
+        <query objectName="java.lang:type=Threading" resultAlias="jvm.thread"/>
+    </queries>
+    <outputWriter class="org.jmxtrans.agent.ConsoleOutputWriter" />
+    <collectIntervalInSeconds>11</collectIntervalInSeconds>
+</jmxtrans-agent>


### PR DESCRIPTION
We have many cases where we want to collect a subset of the attributes for a MBean. In these cases we want to avoid duplicating the `resultAlias` and `objectName`.

This PR adds support for a comma-separated list of attributes to allow for queries such as:
```
<query objectName="java.lang:type=GarbageCollector,name=*"
    attribute="CollectionTime,CollectionCount"
    resultAlias="jvm.gc.%name%.#attribute#"/>
```

It looks a bit weird to still have the XML attribute called "attribute" when it in fact supports many attributes. I'm open to suggestions if you want that changed.

If you accept this PR I can update the README with information about this (and about the support for selecting all attributes, which doesn't seem to be clearly documented now).