### PR TITLE
Add functions to retrieve the MXBean domain

### DIFF
--- a/src/main/java/org/jmxtrans/agent/ExpressionLanguageEngineImpl.java
+++ b/src/main/java/org/jmxtrans/agent/ExpressionLanguageEngineImpl.java
@@ -61,6 +61,8 @@ public class ExpressionLanguageEngineImpl implements ExpressionLanguageEngine {
             functionsByName.put("key", new ExtractCompositeDataKeyFunction());
             functionsByName.put("compositeDataKey", new ExtractCompositeDataKeyFunction());
             functionsByName.put("position", new ExtractPositionFunction());
+            functionsByName.put("domain", new ExtractDomainFunction());
+            functionsByName.put("reversed_domain", new ExtractReversedDomainFunction());
         } catch (Exception e) {
             logger.log(Level.SEVERE, "Exception resolving localhost, expressions like #hostname#, #canonical_hostname# or #hostaddress# will not be available", e);
         }
@@ -246,6 +248,30 @@ public class ExpressionLanguageEngineImpl implements ExpressionLanguageEngine {
         @Override
         public String evaluate(@Nullable ObjectName objectName, @Nullable String attribute, @Nullable String compositeDataKey, @Nullable Integer position) {
             return position == null ? null : position.toString();
+        }
+    }
+
+    private static class ExtractDomainFunction implements Function {
+        @Override
+        public String evaluate() {
+            return null;
+        }
+
+        @Override
+        public String evaluate(@Nullable ObjectName objectName, @Nullable String attribute, @Nullable String compositeDataKey, @Nullable Integer position) {
+            return objectName == null ? null : objectName.getDomain();
+        }
+    }
+
+    private static class ExtractReversedDomainFunction implements Function {
+        @Override
+        public String evaluate() {
+            return null;
+        }
+
+        @Override
+        public String evaluate(@Nullable ObjectName objectName, @Nullable String attribute, @Nullable String compositeDataKey, @Nullable Integer position) {
+            return objectName == null ? null : StringUtils2.reverseTokens(objectName.getDomain(), ".");
         }
     }
 }

--- a/src/test/java/org/jmxtrans/agent/ExpressionLanguageEngineTest.java
+++ b/src/test/java/org/jmxtrans/agent/ExpressionLanguageEngineTest.java
@@ -64,6 +64,27 @@ public class ExpressionLanguageEngineTest {
         assertThat(actual, is("tomcat1.tomcat.datasource.localhost._.jdbc_my-datasource.numActive"));
     }
 
+    /**
+     * Systems like Solr may include valuable information in the MXBean domain (ex: Solr core name). Test a function to
+     * retrieve that domain.
+     * @throws Exception
+     */
+    @Test
+    public void test_resolve_expression_with_domain() throws Exception {
+        // prepare
+        String regular = "#hostname#.#domain#.%type%.%id%";
+        String reversed = "#hostname#.#reversed_domain#.%type%.%id%";
+        String objectName = "solr/demo.solr:type=/spell,id=Lazy[solr.SearchHandler]";
+
+        // test
+        String withRegularDomain = expressionLanguageEngine.resolveExpression(regular, new ObjectName(objectName), "numActive", null, null);
+        String withReversedDomain = expressionLanguageEngine.resolveExpression(reversed, new ObjectName(objectName), "numActive", null, null);
+
+        // verify
+        assertThat(withRegularDomain, is("tomcat1.solr_demo.solr._spell.Lazy_solr_SearchHandler_"));
+        assertThat(withReversedDomain, is("tomcat1.solr.solr_demo._spell.Lazy_solr_SearchHandler_"));
+    }
+
 
     @Test
     public void test_resolve_expression_with_composite_data_key() throws Exception {


### PR DESCRIPTION
Some systems (like Solr) may include valuable information in the MXBean
domain. This commit adds two new functions `domain` and
`reversed_domain` which retrieves it, optionally reverse it, and make it
available in the result alias.

Example of Solr MXBean:

```
solr/demo.solr:type=/spell,id=Lazy[solr.SearchHandler]
```

If the domain contains multiple dots, it may be useful to reverse it.
Hence the additional `reversed_domain` function.