### PR TITLE
Support for dynamic reloading of the configuration file

### DIFF
--- a/src/main/java/org/jmxtrans/agent/ConfigReloadWatcher.java
+++ b/src/main/java/org/jmxtrans/agent/ConfigReloadWatcher.java
@@ -1,0 +1,144 @@
+/*
+ * Copyright (c) 2010-2013 the original author or authors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+ * LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ */
+package org.jmxtrans.agent;
+
+import java.util.logging.Level;
+
+import org.jmxtrans.agent.util.logging.Logger;
+import org.w3c.dom.Document;
+
+/**
+ * Watches a configuration source and notifies a listener when changes are detected.
+ * 
+ * @author Kristoffer Erlandsson
+ */
+public final class ConfigReloadWatcher {
+
+    private static final Logger logger = Logger.getLogger(ConfigReloadWatcher.class.getName());
+
+    private Thread watchThread;
+
+    /**
+     * @param configurationChangedListener
+     *            The listener to notify when changes are detected.
+     * @param initialConfiguration
+     *            The initial configuration. How often to check for changes are read from here. It will also be the
+     *            initial state to compare against when detecting changes.
+     * @param configLoader
+     *            This is the configuration source, configuration is loaded from here and compared against the current
+     *            configuration.
+     */
+    public ConfigReloadWatcher(ConfigurationChangedListener configurationChangedListener,
+            JmxTransExporterConfiguration initialConfiguration,
+            ConfigurationDocumentLoader configLoader) {
+        watchThread = new Thread(new WatcherRunnable(configurationChangedListener, initialConfiguration, configLoader));
+        watchThread.setDaemon(true);
+        watchThread.setName("jmxtrans-agent-config-reload-watcher");
+    }
+
+    private static class WatcherRunnable implements Runnable {
+        private JmxTransExporterConfiguration currentConfiguration;
+        private final ConfigurationChangedListener configurationChangedListener;
+        private final ConfigurationDocumentLoader configLoader;
+
+        public WatcherRunnable(ConfigurationChangedListener configurationChangedListener,
+                JmxTransExporterConfiguration initialConfiguration,
+                ConfigurationDocumentLoader configLoader) {
+            this.configurationChangedListener = configurationChangedListener;
+            this.currentConfiguration = initialConfiguration;
+            this.configLoader = configLoader;
+
+        }
+
+        @Override
+        public void run() {
+            logger.log(Level.INFO, "Starting config reload watcher, will check for configuration changes every "
+                    + currentConfiguration.getConfigReloadInterval() + " seconds");
+            while (!Thread.interrupted()) {
+                try {
+                    Thread.sleep(calculateSleepMillis(currentConfiguration.getConfigReloadInterval()));
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                    break;
+                }
+                checkAndHandleChangedConfiguration();
+                if (currentConfiguration.getConfigReloadInterval() < 0) {
+                    // Configuration has been updated with disabling of reload
+                    logger.log(Level.INFO, "Config reloading disabled, stopping watcher");
+                    return;
+                }
+            }
+            logger.log(Level.INFO, "Config reload watcher interrupted, watcher stopped");
+        }
+
+        private int calculateSleepMillis(Integer configReloadInterval) {
+            // Sleep 10 ms if reload interval is 0 to avoid busy-wait
+            return configReloadInterval != 0 ? configReloadInterval * 1000 : 10;
+        }
+
+        private void checkAndHandleChangedConfiguration() {
+            Document sourceDocument;
+            try {
+                sourceDocument = configLoader.loadConfiguration();
+            } catch (Exception e) {
+                logger.log(Level.WARNING,
+                        "Error when checking if configuration " + configLoader
+                                + " changed, current config will be kept",
+                        e);
+                return;
+            }
+            if (currentConfigDiffers(sourceDocument)) {
+                loadAndNotifyConfigurationChanged(sourceDocument);
+            }
+        }
+
+        private void loadAndNotifyConfigurationChanged(Document sourceDocument) {
+            logger.log(Level.INFO, "Detected changed configuration, will reload " + configLoader);
+            JmxTransExporterConfiguration newConfig;
+            try {
+                newConfig = new JmxTransExporterBuilder().build(sourceDocument);
+                configurationChangedListener.configurationChanged(newConfig);
+                currentConfiguration = newConfig;
+            } catch (Exception e) {
+                logger.log(Level.WARNING,
+                        "Error when reloading configuration " + configLoader + ", current config will be kept", e);
+            }
+        }
+
+        private boolean currentConfigDiffers(Document sourceDocument) {
+            return !sourceDocument.isEqualNode(currentConfiguration.getDocument());
+        }
+    }
+
+    public void start() {
+        watchThread.start();
+    }
+
+    public void stop() {
+        if (watchThread != null) {
+            watchThread.interrupt();
+        }
+    }
+
+}

--- a/src/main/java/org/jmxtrans/agent/ConfigurationChangedListener.java
+++ b/src/main/java/org/jmxtrans/agent/ConfigurationChangedListener.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2010-2013 the original author or authors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+ * LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ */
+package org.jmxtrans.agent;
+
+public interface ConfigurationChangedListener {
+
+    /**
+     * Will be called when the configuration has been changed, if dynamic config reloading is enabled.
+     * 
+     * @param configuration The new configuration:
+     */
+    void configurationChanged(JmxTransExporterConfiguration configuration);
+}

--- a/src/main/java/org/jmxtrans/agent/ConfigurationDocumentLoader.java
+++ b/src/main/java/org/jmxtrans/agent/ConfigurationDocumentLoader.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2010-2013 the original author or authors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+ * LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ */
+package org.jmxtrans.agent;
+
+import org.w3c.dom.Document;
+
+/**
+ * @author Kristoffer Erlandsson
+ */
+public interface ConfigurationDocumentLoader {
+
+    Document loadConfiguration() throws Exception;
+}

--- a/src/main/java/org/jmxtrans/agent/GraphitePlainTextTcpOutputWriter.java
+++ b/src/main/java/org/jmxtrans/agent/GraphitePlainTextTcpOutputWriter.java
@@ -160,6 +160,12 @@ public class GraphitePlainTextTcpOutputWriter extends AbstractOutputWriter imple
                 '}';
     }
     
+    @Override
+    public void preDestroy() {
+        super.preDestroy();
+        releaseGraphiteConnection();
+    };
+    
     String getMetricPathPrefix() {
         return messageBuilder.getPrefix();
     }

--- a/src/main/java/org/jmxtrans/agent/JmxTransConfigurationDocumentLoader.java
+++ b/src/main/java/org/jmxtrans/agent/JmxTransConfigurationDocumentLoader.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright (c) 2010-2013 the original author or authors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+ * LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ */
+package org.jmxtrans.agent;
+
+import java.io.File;
+import java.io.InputStream;
+import java.net.URL;
+
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+
+import org.w3c.dom.Document;
+
+public class JmxTransConfigurationDocumentLoader implements ConfigurationDocumentLoader {
+
+    private final String configurationFilePath;
+
+
+    /**
+     * Creates a loader that will load a document from the specified path.
+     */
+    public JmxTransConfigurationDocumentLoader(String configurationFilePath) {
+        if (configurationFilePath == null) {
+            throw new NullPointerException("configurationFilePath cannot be null");
+        }
+        this.configurationFilePath = configurationFilePath;
+    }
+
+
+    @Override
+    public Document loadConfiguration() throws Exception {
+        DocumentBuilder dBuilder = DocumentBuilderFactory.newInstance().newDocumentBuilder();
+
+        Document document;
+        if (configurationFilePath.toLowerCase().startsWith("classpath:")) {
+            String classpathResourcePath = configurationFilePath.substring("classpath:".length());
+            InputStream in = Thread.currentThread().getContextClassLoader().getResourceAsStream(classpathResourcePath);
+            document = dBuilder.parse(in);
+        } else if (configurationFilePath.toLowerCase().startsWith("file://") ||
+                configurationFilePath.toLowerCase().startsWith("http://") ||
+                configurationFilePath.toLowerCase().startsWith("https://")
+                ) {
+            URL url = new URL(configurationFilePath);
+            document = dBuilder.parse(url.openStream());
+        } else {
+            File xmlFile = new File(configurationFilePath);
+            if (!xmlFile.exists()) {
+                throw new IllegalArgumentException("Configuration file '" + xmlFile.getAbsolutePath() + "' not found");
+            }
+            document = dBuilder.parse(xmlFile);
+        }
+        return document;
+    }
+
+    @Override
+    public String toString() {
+        return configurationFilePath;
+    }
+}

--- a/src/main/java/org/jmxtrans/agent/JmxTransExporter.java
+++ b/src/main/java/org/jmxtrans/agent/JmxTransExporter.java
@@ -54,7 +54,8 @@ public class JmxTransExporter implements ConfigurationChangedListener {
     private ScheduledExecutorService scheduledExecutorService = Executors.newScheduledThreadPool(1, threadFactory);
     private MBeanServer mbeanServer = ManagementFactory.getPlatformMBeanServer();
     private ScheduledFuture scheduledFuture;
-    private volatile JmxTransExporterConfiguration config;
+    private JmxTransExporterConfiguration config;
+    private volatile JmxTransExporterConfiguration newConfiguration;
 
     public JmxTransExporter(JmxTransExporterConfiguration config) {
         this.config = config;
@@ -106,6 +107,7 @@ public class JmxTransExporter implements ConfigurationChangedListener {
     }
 
     protected void collectAndExport() {
+        replaceConfigurationIfChanged();
         OutputWriter outputWriter = config.getOutputWriter();
         try {
             outputWriter.preCollect();
@@ -129,6 +131,15 @@ public class JmxTransExporter implements ConfigurationChangedListener {
         }
     }
 
+    private void replaceConfigurationIfChanged() {
+        if (newConfiguration != null) {
+            logger.log(Level.INFO, "Configuration has changed, destroying the old configuration and replacing with the new");
+            config.destroy();
+            config = newConfiguration;
+            newConfiguration = null;
+        }
+    }
+
     @Override
     public String toString() {
         return "JmxTransExporter{" +
@@ -138,6 +149,6 @@ public class JmxTransExporter implements ConfigurationChangedListener {
 
     @Override
     public void configurationChanged(JmxTransExporterConfiguration configuration) {
-        this.config = configuration;
+        this.newConfiguration = configuration;
     }
 }

--- a/src/main/java/org/jmxtrans/agent/JmxTransExporterConfiguration.java
+++ b/src/main/java/org/jmxtrans/agent/JmxTransExporterConfiguration.java
@@ -1,0 +1,145 @@
+/*
+ * Copyright (c) 2010-2013 the original author or authors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+ * LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ */
+package org.jmxtrans.agent;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+import org.w3c.dom.Document;
+
+/**
+ * @author <a href="mailto:cleclerc@cloudbees.com">Cyrille Le Clerc</a>
+ * @author Kristoffer Erlandsson
+ */
+public class JmxTransExporterConfiguration {
+
+    /**
+     * visible for test
+     */
+    protected List<Query> queries = new ArrayList<Query>();
+    /**
+     * visible for test
+     */
+    protected List<Invocation> invocations = new ArrayList<Invocation>();
+    /**
+     * visible for test
+     */
+    protected OutputWriter outputWriter = new DevNullOutputWriter();
+
+    protected ResultNameStrategy resultNameStrategy;
+    protected int collectInterval = 10;
+    protected TimeUnit collectIntervalTimeUnit = TimeUnit.SECONDS;
+    private int configReloadInterval = -1; // -1 == never (0 = check very often, < 10ms between checks)
+    private Document document;
+
+    /**
+     * @param document
+     *            The document used when creating this configuration. Will be used to detect configuration changes in
+     *            the underlying configuration file. No configuration will be read from this document - configuration
+     *            has to be explicitly set with the withXxx methods.
+     */
+    public JmxTransExporterConfiguration(Document document) {
+        this.document = document;
+    }
+
+    public JmxTransExporterConfiguration withQuery(@Nonnull String objectName, @Nonnull List<String> attributes, @Nullable String resultAlias) {
+        return withQuery(objectName, attributes, null, null, null, resultAlias);
+    }
+
+    public JmxTransExporterConfiguration withQuery(@Nonnull String objectName, @Nonnull List<String> attributes, @Nullable String key,
+                                      @Nullable Integer position, @Nullable String type, @Nullable String resultAlias) {
+        Query query = new Query(objectName, attributes, key, position, type, resultAlias, this.resultNameStrategy);
+        queries.add(query);
+        return this;
+    }
+    public JmxTransExporterConfiguration withInvocation(@Nonnull String objectName, @Nonnull String operation, @Nullable String resultAlias) {
+        invocations.add(new Invocation(objectName, operation, new Object[0], new String[0], resultAlias));
+        return this;
+    }
+    public JmxTransExporterConfiguration withOutputWriter(OutputWriter outputWriter) {
+        this.outputWriter = outputWriter;
+        return this;
+    }
+
+    public JmxTransExporterConfiguration withCollectInterval(int collectInterval, @Nonnull TimeUnit collectIntervalTimeUnit) {
+        this.collectInterval = collectInterval;
+        this.collectIntervalTimeUnit = collectIntervalTimeUnit;
+        return this;
+    }
+    
+    public JmxTransExporterConfiguration withConfigReloadInterval(int configReloadInterval) {
+        if (configReloadInterval < 0) {
+            throw new IllegalArgumentException("configReloadInterval must be >= 0, was: " + configReloadInterval);
+        }
+        this.configReloadInterval = configReloadInterval;
+        return this;
+    }
+
+    public List<Query> getQueries() {
+        return queries;
+    }
+
+    public List<Invocation> getInvocations() {
+        return invocations;
+    }
+
+    public OutputWriter getOutputWriter() {
+        return outputWriter;
+    }
+
+    public ResultNameStrategy getResultNameStrategy() {
+        return resultNameStrategy;
+    }
+
+    public int getCollectInterval() {
+        return collectInterval;
+    }
+
+    public TimeUnit getCollectIntervalTimeUnit() {
+        return collectIntervalTimeUnit;
+    }
+
+    @Override
+    public String toString() {
+        return "JmxTransExporterConfiguration{" +
+                "queries=" + queries +
+                ", invocations=" + invocations +
+                ", outputWriter=" + outputWriter +
+                ", collectInterval=" + collectInterval +
+                " " + collectIntervalTimeUnit +
+                '}';
+    }
+
+    public Integer getConfigReloadInterval() {
+        return configReloadInterval;
+    }
+
+    public Document getDocument() {
+        return document;
+    }
+}

--- a/src/main/java/org/jmxtrans/agent/JmxTransExporterConfiguration.java
+++ b/src/main/java/org/jmxtrans/agent/JmxTransExporterConfiguration.java
@@ -142,4 +142,8 @@ public class JmxTransExporterConfiguration {
     public Document getDocument() {
         return document;
     }
+
+    public void destroy() {
+        getOutputWriter().preDestroy();
+    }
 }

--- a/src/test/java/org/jmxtrans/agent/ConfigReloadWatcherTest.java
+++ b/src/test/java/org/jmxtrans/agent/ConfigReloadWatcherTest.java
@@ -1,0 +1,147 @@
+/*
+ * Copyright (c) 2010-2013 the original author or authors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+ * LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ */
+package org.jmxtrans.agent;
+
+import static org.hamcrest.Matchers.*;
+import static org.junit.Assert.*;
+
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+import java.nio.charset.Charset;
+
+import javax.xml.parsers.DocumentBuilderFactory;
+
+import org.hamcrest.Matcher;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.w3c.dom.Document;
+
+public class ConfigReloadWatcherTest {
+
+    String testXml = "<jmxtrans-agent>\r\n" + 
+            "    <outputWriter class=\"org.jmxtrans.agent.ConsoleOutputWriter\" />\r\n" + 
+            "    <reloadConfigurationCheckIntervalInSeconds>0</reloadConfigurationCheckIntervalInSeconds>\r\n" + 
+            "</jmxtrans-agent>";
+            
+    private FakeConfigurationChangedListener listener;
+
+    private FakeConfigLoader configLoader;
+
+    private JmxTransExporterConfiguration initialConfiguration;
+
+    private ConfigReloadWatcher watcher;
+    
+    
+    @Before
+    public void setUp() throws Exception {
+       listener = new FakeConfigurationChangedListener();
+       configLoader = new FakeConfigLoader(testXml);
+       initialConfiguration = new JmxTransExporterConfiguration(configLoader.loadConfiguration());
+       initialConfiguration.withConfigReloadInterval(0);
+       watcher = new ConfigReloadWatcher(listener, initialConfiguration, configLoader); 
+    }
+
+    @After
+    public void stopWatcher() {
+        if (watcher != null) {
+            watcher.stop();
+        }
+    }
+
+    @Test
+    public void listenerNotNotifiedWhenConfigurationDoesNotChange() throws Exception {
+       watcher.start();
+       Thread.sleep(100);
+       assertThat(listener.notifiedWith, nullValue());
+    }
+
+    @Test
+    public void listenerNotified() throws Exception {
+       watcher.start();
+       configLoader.setXml(testXml + "<!-- -->");
+       assertEventuallyListenerNotifiedWith(listener, notNullValue(JmxTransExporterConfiguration.class));
+    }
+    
+    @Test
+    public void errorDuringConfigurationLoad() throws Exception {
+       watcher.start();
+       configLoader.setExceptionToThrow(new Exception());
+       configLoader.setXml(testXml + "<!-- -->");
+       Thread.sleep(50);
+       assertThat(listener.notifiedWith, nullValue()); // No notificactions when config cannot be loaded
+       configLoader.setExceptionToThrow(null);
+       assertEventuallyListenerNotifiedWith(listener, notNullValue(JmxTransExporterConfiguration.class));
+    }
+    
+    public void assertEventuallyListenerNotifiedWith(FakeConfigurationChangedListener listener, Matcher<JmxTransExporterConfiguration> matcher)
+            throws Exception {
+        for (int i = 0; i < 100; i++) {
+            if (matcher.matches(listener.notifiedWith)) {
+                return;
+            }
+            Thread.sleep(10);
+        }
+        assertThat(listener.notifiedWith, matcher);
+    }
+    
+    private static class FakeConfigurationChangedListener implements ConfigurationChangedListener {
+
+        private volatile JmxTransExporterConfiguration notifiedWith;
+
+        @Override
+        public void configurationChanged(JmxTransExporterConfiguration configuration) {
+            this.notifiedWith = configuration;
+        }
+        
+    }
+    
+    private static class FakeConfigLoader implements ConfigurationDocumentLoader {
+        
+        private volatile String xml;
+        private volatile Exception exception;
+
+        public FakeConfigLoader(String xml) {
+            this.xml = xml;
+        }
+
+        @Override
+        public Document loadConfiguration() throws Exception {
+            if (exception != null) {
+                throw exception;
+            }
+            InputStream is = new ByteArrayInputStream(xml.getBytes(Charset.defaultCharset()));
+            return DocumentBuilderFactory.newInstance().newDocumentBuilder().parse(is);
+        }
+        
+        public void setXml(String xml) {
+            this.xml = xml;
+        }
+        
+        public void setExceptionToThrow(Exception e) {
+            this.exception = e;
+        }
+
+    }
+}

--- a/src/test/resources/jmxtrans-config-reload-test.xml
+++ b/src/test/resources/jmxtrans-config-reload-test.xml
@@ -1,0 +1,30 @@
+<!--
+ ~ Copyright (c) 2010-2013 the original author or authors
+ ~
+ ~ Permission is hereby granted, free of charge, to any person obtaining
+ ~ a copy of this software and associated documentation files (the
+ ~ "Software"), to deal in the Software without restriction, including
+ ~ without limitation the rights to use, copy, modify, merge, publish,
+ ~ distribute, sublicense, and/or sell copies of the Software, and to
+ ~ permit persons to whom the Software is furnished to do so, subject to
+ ~ the following conditions:
+ ~
+ ~ The above copyright notice and this permission notice shall be
+ ~ included in all copies or substantial portions of the Software.
+ ~
+ ~ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ ~ EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ ~ MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ ~ NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+ ~ LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ ~ OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ ~ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ ~
+-->
+<jmxtrans-agent>
+    <queries>
+        <query objectName="java.lang:type=Threading" attribute="ThreadCount" resultAlias="jvm.thread"/>
+    </queries>
+    <outputWriter class="org.jmxtrans.agent.ConsoleOutputWriter" />
+    <reloadConfigurationCheckIntervalInSeconds>2</reloadConfigurationCheckIntervalInSeconds>
+</jmxtrans-agent>


### PR DESCRIPTION
Support for reloading the configuration file at runtime. By adding

```xml
<reloadConfigurationCheckIntervalInSeconds>X</reloadConfigurationCheckIntervalInSeconds>
```

to the configuration, the configuration file is polled every X seconds for changes. The configuration is loaded as an XML document and compared against the current configuration - if changes are detected, the new configuration is loaded. This way we can support URL configuration sources which would not be possible if we only checked file modification timestamps.

This PR became quite big since there were some refactoring required. Currently the `collectInterval` is not updated dynamically - that would have required even more refactoring. I will look into that when I work on issue #56. 

A summary of the changes:
* Added `ConfigReloadWatcher` that handles the actual watching and notification of updated configuration
* Moved all the configuration from `JmxTransExporter` to the new `JmxTransExporterConfiguration`
* Moved loading of the configuration XML document from `JmxTransExporterBuilder` to `JmxTransConfigurationDocumentLoader` so that it can be reused in the watcher
* Lots of minor changes to accomodate theese refactorings

Any feedback you may have is welcome.