### PR TITLE
Release the connection if the writer fails to flush.

### DIFF
--- a/src/main/java/org/jmxtrans/agent/GraphitePlainTextTcpOutputWriter.java
+++ b/src/main/java/org/jmxtrans/agent/GraphitePlainTextTcpOutputWriter.java
@@ -149,7 +149,13 @@ public class GraphitePlainTextTcpOutputWriter extends AbstractOutputWriter imple
             return;
         }
 
-        writer.flush();
+        try {
+            writer.flush();
+        } catch (IOException e) {
+            logger.log(Level.WARNING, "Exception flushing the stream to " + graphiteServerHostAndPort, e);
+            releaseGraphiteConnection();
+            throw e;
+        }
     }
 
     @Override
@@ -159,7 +165,7 @@ public class GraphitePlainTextTcpOutputWriter extends AbstractOutputWriter imple
                 ", metricPathPrefix='" + messageBuilder.getPrefix() + '\'' +
                 '}';
     }
-    
+
     String getMetricPathPrefix() {
         return messageBuilder.getPrefix();
     }


### PR DESCRIPTION
When an exception is thrown while flushing the stream, the socket isn't cleaned up and the agent will continue to use the broken socket.  We are using a hostname for the endpoint.  When we update the endpoint and change IP addresses, the writer will throw an exception for a broken pipe.  The agent will continue to use the socket and get exceptions for a broken pipe until the service is restarted.