### PR TITLE
Fixed test that was broken on Windows + volatile config

### DIFF
--- a/src/main/java/org/jmxtrans/agent/JmxTransExporter.java
+++ b/src/main/java/org/jmxtrans/agent/JmxTransExporter.java
@@ -57,7 +57,7 @@ public class JmxTransExporter {
     private MBeanServer mbeanServer = ManagementFactory.getPlatformMBeanServer();
     private ScheduledFuture scheduledFuture;
     private JmxTransConfigurationLoader configLoader;
-    private JmxTransExporterConfiguration config;
+    private volatile JmxTransExporterConfiguration config;
 
     public JmxTransExporter(JmxTransConfigurationLoader configLoader) {
         this.configLoader = configLoader;

--- a/src/test/java/org/jmxtrans/agent/util/io/IoUtilsTest.java
+++ b/src/test/java/org/jmxtrans/agent/util/io/IoUtilsTest.java
@@ -57,12 +57,21 @@ public class IoUtilsTest {
             assertThat((lastModificationDate - before) + "ms", Math.abs(lastModificationDate - before), lessThan(1000L));
         }
         {
-            String fileUrl = "file://" + filePath;
+            String fileUrl = createFileUrl(filePath);
             long lastModificationDate = IoUtils.getFileLastModificationDate(fileUrl);
             System.out.println(filePath + "\t" + new Timestamp(lastModificationDate) + "\t" + lastModificationDate);
             // the precision of last modified may not very good, take a margin of 1sec
             assertThat((lastModificationDate - before) + "ms", Math.abs(lastModificationDate - before), lessThan(1000L));
         }
+    }
+    
+    private String createFileUrl(String filePath) {
+        // On windows machines we must replace backslashes with forward slashes and add a preceding slash.
+        String res = filePath.replace('\\', '/');
+        if (!res.startsWith("/")) {
+            res = "/" + res;
+        }
+        return "file://" + res;
     }
 
     @Test
@@ -80,7 +89,7 @@ public class IoUtilsTest {
             assertThat(document, notNullValue());
         }
         {
-            String fileUrl = "file://" + filePath;
+            String fileUrl = createFileUrl(filePath);
             System.out.println(fileUrl);
             Document document = IoUtils.getFileAsDocument(fileUrl);
             System.out.println(document.getDocumentElement());


### PR DESCRIPTION
Two minor fixes:

* `IoUtilsTest` failed on Windows since file URLs can not contain backslashes and must start with a slash to be absolute.
* The `config` field in `JmxTransExporter` should be volatile since it is written and read by different threads.