### PR TITLE
Simplify the generics declaration by using the diamond operator ("<>") to reduce the verbosity of generics code.

### DIFF
--- a/src/main/java/org/jmxtrans/agent/ExpressionLanguageEngineImpl.java
+++ b/src/main/java/org/jmxtrans/agent/ExpressionLanguageEngineImpl.java
@@ -72,7 +72,7 @@ public class ExpressionLanguageEngineImpl implements ExpressionLanguageEngine {
      * Function based evaluators for expressions like '#hostname#' or '#hostname_canonical#'
      */
     @Nonnull
-    private Map<String, Function> functionsByName = new HashMap<String, Function>();
+    private Map<String, Function> functionsByName = new HashMap<>();
 
     /**
      * Replace all the '#' based keywords (e.g. <code>#hostname#</code>) by their value.

--- a/src/main/java/org/jmxtrans/agent/JmxTransConfigurationXmlLoader.java
+++ b/src/main/java/org/jmxtrans/agent/JmxTransConfigurationXmlLoader.java
@@ -221,7 +221,7 @@ public class JmxTransConfigurationXmlLoader implements JmxTransConfigurationLoad
 
                 try {
                     resultNameStrategy = (ResultNameStrategy) Class.forName(outputWriterClass).newInstance();
-                    Map<String, String> settings = new HashMap<String, String>();
+                    Map<String, String> settings = new HashMap<>();
                     NodeList settingsNodeList = resultNameStrategyElement.getElementsByTagName("*");
                     for (int j = 0; j < settingsNodeList.getLength(); j++) {
                         Element settingElement = (Element) settingsNodeList.item(j);
@@ -241,7 +241,7 @@ public class JmxTransConfigurationXmlLoader implements JmxTransConfigurationLoad
 
     private void buildOutputWriters(Element rootElement, JmxTransExporterConfiguration configuration, PropertyPlaceholderResolver placeholderResolver) {
         NodeList outputWriterNodeList = rootElement.getElementsByTagName("outputWriter");
-        List<OutputWriter> outputWriters = new ArrayList<OutputWriter>();
+        List<OutputWriter> outputWriters = new ArrayList<>();
 
         for (int i = 0; i < outputWriterNodeList.getLength(); i++) {
             Element outputWriterElement = (Element) outputWriterNodeList.item(i);
@@ -252,7 +252,7 @@ public class JmxTransConfigurationXmlLoader implements JmxTransConfigurationLoad
             OutputWriter outputWriter;
             try {
                 outputWriter = (OutputWriter) Class.forName(outputWriterClass).newInstance();
-                Map<String, String> settings = new HashMap<String, String>();
+                Map<String, String> settings = new HashMap<>();
                 NodeList settingsNodeList = outputWriterElement.getElementsByTagName("*");
                 for (int j = 0; j < settingsNodeList.getLength(); j++) {
                     Element settingElement = (Element) settingsNodeList.item(j);

--- a/src/main/java/org/jmxtrans/agent/JmxTransExporterConfiguration.java
+++ b/src/main/java/org/jmxtrans/agent/JmxTransExporterConfiguration.java
@@ -41,11 +41,11 @@ public class JmxTransExporterConfiguration {
     /**
      * visible for test
      */
-    protected List<Query> queries = new ArrayList<Query>();
+    protected List<Query> queries = new ArrayList<>();
     /**
      * visible for test
      */
-    protected List<Invocation> invocations = new ArrayList<Invocation>();
+    protected List<Invocation> invocations = new ArrayList<>();
     /**
      * visible for test
      */

--- a/src/main/java/org/jmxtrans/agent/OutputWritersChain.java
+++ b/src/main/java/org/jmxtrans/agent/OutputWritersChain.java
@@ -35,11 +35,11 @@ public class OutputWritersChain extends AbstractOutputWriter implements OutputWr
     protected final List<OutputWriter> outputWriters;
 
     public OutputWritersChain() {
-        outputWriters = new ArrayList<OutputWriter>();
+        outputWriters = new ArrayList<>();
     }
 
     public OutputWritersChain(List<OutputWriter> outputWriters) {
-        this.outputWriters = new ArrayList<OutputWriter>(outputWriters.size());
+        this.outputWriters = new ArrayList<>(outputWriters.size());
         this.outputWriters.addAll(outputWriters);
     }
 

--- a/src/main/java/org/jmxtrans/agent/PerMinuteSummarizerOutputWriter.java
+++ b/src/main/java/org/jmxtrans/agent/PerMinuteSummarizerOutputWriter.java
@@ -41,7 +41,7 @@ import java.util.concurrent.TimeUnit;
 public class PerMinuteSummarizerOutputWriter extends AbstractOutputWriter implements OutputWriter {
 
     protected OutputWriter delegate;
-    protected Map<String, Queue<QueryResult>> previousQueryResultsByMetricName = new HashMap<String, Queue<QueryResult>>();
+    protected Map<String, Queue<QueryResult>> previousQueryResultsByMetricName = new HashMap<>();
 
     public PerMinuteSummarizerOutputWriter() {
     }
@@ -87,7 +87,7 @@ public class PerMinuteSummarizerOutputWriter extends AbstractOutputWriter implem
 
         Queue<QueryResult> queue = previousQueryResultsByMetricName.get(currentResult.getName());
         if (queue == null) {
-            queue = new EvictingQueue<QueryResult>(3);
+            queue = new EvictingQueue<>(3);
             previousQueryResultsByMetricName.put(currentResult.getName(), queue);
         }
         queue.add(currentResult);

--- a/src/main/java/org/jmxtrans/agent/util/StringUtils2.java
+++ b/src/main/java/org/jmxtrans/agent/util/StringUtils2.java
@@ -50,7 +50,7 @@ public class StringUtils2 {
         }
         String[] splits = delimitedString.split("[,;\\n]");
 
-        List<String> result = new ArrayList<String>();
+        List<String> result = new ArrayList<>();
 
         for (String split : splits) {
             split = split.trim();
@@ -104,7 +104,7 @@ public class StringUtils2 {
         Preconditions2.checkNotNull(delimiter, "given delimiter can not be null");
 
         StringTokenizer st = new StringTokenizer(str, delimiter);
-        List<String> tokens = new ArrayList<String>();
+        List<String> tokens = new ArrayList<>();
 
         while (st.hasMoreTokens()) {
             tokens.add(st.nextToken());

--- a/src/main/java/org/jmxtrans/agent/util/collect/EvictingQueue.java
+++ b/src/main/java/org/jmxtrans/agent/util/collect/EvictingQueue.java
@@ -33,7 +33,7 @@ public class EvictingQueue<E> extends ForwardingQueue<E> implements Queue<E> {
     }
 
     public static <E> EvictingQueue<E> create(int maxCapacity) {
-        return new EvictingQueue<E>(maxCapacity);
+        return new EvictingQueue<>(maxCapacity);
     }
 
     @Nonnull

--- a/src/test/java/org/jmxtrans/agent/JmxTransConfigurationXmlLoaderTest.java
+++ b/src/test/java/org/jmxtrans/agent/JmxTransConfigurationXmlLoaderTest.java
@@ -204,7 +204,7 @@ public class JmxTransConfigurationXmlLoaderTest {
     }
 
     Map<String, Query> indexQueriesByResultAlias(Iterable<Query> queries) {
-        Map<String, Query> result = new HashMap<String, Query>();
+        Map<String, Query> result = new HashMap<>();
         for (Query query : queries) {
             result.put(query.resultAlias, query);
         }

--- a/src/test/java/org/jmxtrans/agent/LibratoMetricsIntegrationTest.java
+++ b/src/test/java/org/jmxtrans/agent/LibratoMetricsIntegrationTest.java
@@ -51,7 +51,7 @@ public class LibratoMetricsIntegrationTest {
         config.load(in);
 
         libratoWriter = new LibratoWriter();
-        Map<String, String> settings = new HashMap<String, String>();
+        Map<String, String> settings = new HashMap<>();
         settings.put(LibratoWriter.SETTING_USERNAME,config.getProperty("LIBRATO_USER"));
         settings.put(LibratoWriter.SETTING_TOKEN, config.getProperty("LIBRATO_TOKEN"));
 

--- a/src/test/java/org/jmxtrans/agent/QueryTest.java
+++ b/src/test/java/org/jmxtrans/agent/QueryTest.java
@@ -213,7 +213,7 @@ public class QueryTest {
     public static class MockOutputWriter extends AbstractOutputWriter {
 
         protected final boolean failOnDuplicateResult;
-        protected final Map<String, Object> resultsByName = new HashMap<String, Object>();
+        protected final Map<String, Object> resultsByName = new HashMap<>();
 
         public MockOutputWriter() {
             this(true);

--- a/src/test/java/org/jmxtrans/agent/StatsDOutputWriterIntegrationTest.java
+++ b/src/test/java/org/jmxtrans/agent/StatsDOutputWriterIntegrationTest.java
@@ -16,7 +16,7 @@ public class StatsDOutputWriterIntegrationTest {
     @Ignore
     public void test() throws IOException {
         StatsDOutputWriter writer = new StatsDOutputWriter();
-        Map<String, String> settings = new HashMap<String, String>();
+        Map<String, String> settings = new HashMap<>();
         settings.put(StatsDOutputWriter.SETTING_HOST, "localhost");
         settings.put(StatsDOutputWriter.SETTING_PORT, "8125");
         writer.postConstruct(settings);

--- a/src/test/java/org/jmxtrans/agent/util/collect/Iterables2Test.java
+++ b/src/test/java/org/jmxtrans/agent/util/collect/Iterables2Test.java
@@ -44,20 +44,20 @@ public class Iterables2Test {
 
     @Test
     public void get_on_iterator_return_value() {
-        Set<String> in = new TreeSet<String>(Arrays.asList("val0", "val1", "val2", "val3"));
+        Set<String> in = new TreeSet<>(Arrays.asList("val0", "val1", "val2", "val3"));
         String actual = Iterables2.get(in, 2);
         assertThat(actual, is("val2"));
     }
 
     @Test(expected = IndexOutOfBoundsException.class)
     public void get_negative_position_throws_an_exception() {
-        Set<String> in = new HashSet<String>(Arrays.asList("val0", "val1", "val2", "val3"));
+        Set<String> in = new HashSet<>(Arrays.asList("val0", "val1", "val2", "val3"));
         Iterables2.get(in, -1);
     }
 
     @Test(expected = IndexOutOfBoundsException.class)
     public void get_out_of_range_position_throws_an_exception() {
-        Set<String> in = new HashSet<String>(Arrays.asList("val0", "val1", "val2", "val3"));
+        Set<String> in = new HashSet<>(Arrays.asList("val0", "val1", "val2", "val3"));
         Iterables2.get(in, 10);
     }
 }


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S2293 - “ The diamond operator ("<>") should be used ”. You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:S2293
Please let me know if you have any questions.
Ayman Abdelghany.