### PR TITLE
Adding private constructor to util classes (containing static methods only)

### DIFF
--- a/src/main/java/org/jmxtrans/agent/DynamicallyAgentAttacher.java
+++ b/src/main/java/org/jmxtrans/agent/DynamicallyAgentAttacher.java
@@ -6,6 +6,8 @@ import org.jmxtrans.agent.util.logging.Logger;
 public class DynamicallyAgentAttacher {
     private static Logger logger = Logger.getLogger(DynamicallyAgentAttacher.class.getName());
 
+    private DynamicallyAgentAttacher(){}
+    
     public static void main(String[] args) {
         if(args.length != 3) {
             printUsage();

--- a/src/main/java/org/jmxtrans/agent/JmxTransAgent.java
+++ b/src/main/java/org/jmxtrans/agent/JmxTransAgent.java
@@ -51,6 +51,9 @@ public class JmxTransAgent {
 
     private static final String PROPERTIES_SYSTEM_PROPERTY_NAME = "jmxtrans.agent.properties.file";
 
+
+    private JmxTransAgent(){}
+
     @SuppressFBWarnings("MS_SHOULD_BE_FINAL")
     public static boolean DIAGNOSTIC = Boolean.valueOf(System.getProperty(JmxTransAgent.class.getName() + ".diagnostic", "false"));
 

--- a/src/main/java/org/jmxtrans/agent/graphite/GraphiteOutputWriterCommonSettings.java
+++ b/src/main/java/org/jmxtrans/agent/graphite/GraphiteOutputWriterCommonSettings.java
@@ -39,6 +39,8 @@ public class GraphiteOutputWriterCommonSettings {
     public static final int SETTING_PORT_DEFAULT_VALUE = 2003;
     public static final String SETTING_NAME_PREFIX = "namePrefix";
     
+    private GraphiteOutputWriterCommonSettings(){}
+    
     public static HostAndPort getHostAndPort(Map<String, String> settings) {
         return new HostAndPort(getString(settings, SETTING_HOST),
                 getInt(settings, SETTING_PORT, SETTING_PORT_DEFAULT_VALUE));

--- a/src/main/java/org/jmxtrans/agent/util/Preconditions2.java
+++ b/src/main/java/org/jmxtrans/agent/util/Preconditions2.java
@@ -32,6 +32,8 @@ import javax.annotation.Nullable;
  */
 public class Preconditions2 {
 
+    private Preconditions2(){}
+
     public static <T> T checkNotNull(T t) {
         if (t == null)
             throw new NullPointerException();

--- a/src/main/java/org/jmxtrans/agent/util/collect/Iterables2.java
+++ b/src/main/java/org/jmxtrans/agent/util/collect/Iterables2.java
@@ -36,6 +36,8 @@ import java.util.List;
  */
 public class Iterables2 {
 
+    private Iterables2(){}
+    
     /**
      * Returns the element at the specified position in an iterable.
      *

--- a/src/main/java/org/jmxtrans/agent/util/io/IoUtils.java
+++ b/src/main/java/org/jmxtrans/agent/util/io/IoUtils.java
@@ -58,6 +58,8 @@ import javax.xml.parsers.ParserConfigurationException;
 public class IoUtils {
     protected final static Logger logger = Logger.getLogger(IoUtils.class.getName());
 
+    private IoUtils(){}
+
     /**
      * @param filePath can be prefixed by "{@code http://}", "{@code https://}", "{@code file://}". If given value is not prefixed, "{@code file://}" is assumed.
      * @return @return A <code>long</code> value representing the time the file was


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S1118 - “ Utility classes should not have public constructors ”. You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:S1118
Please let me know if you have any questions.
Ayman Abdelghany.