### PR TITLE
Support for overriding the collect interval for individual queries and invocations

### DIFF
--- a/src/main/java/org/jmxtrans/agent/Collector.java
+++ b/src/main/java/org/jmxtrans/agent/Collector.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2010-2013 the original author or authors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+ * LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ */
+package org.jmxtrans.agent;
+
+import javax.management.MBeanServer;
+
+/**
+ * @author Kristoffer Erlandsson
+ */
+public interface Collector {
+
+    void collectAndExport(MBeanServer mbeanServer, OutputWriter outputWriter);
+    
+}

--- a/src/main/java/org/jmxtrans/agent/Invocation.java
+++ b/src/main/java/org/jmxtrans/agent/Invocation.java
@@ -38,7 +38,7 @@ import java.util.logging.Level;
 /**
  * @author <a href="mailto:cleclerc@cloudbees.com">Cyrille Le Clerc</a>
  */
-public class Invocation {
+public class Invocation implements Collector {
 
     @Nullable
     protected final ObjectName objectName;
@@ -51,8 +51,11 @@ public class Invocation {
     @Nonnull
     protected final String[] signature;
     private final Logger logger = Logger.getLogger(getClass().getName());
+    @Nullable
+    private Integer collectInterval;
 
-    public Invocation(@Nullable String objectName, @Nonnull String operationName, @Nonnull Object[] params, @Nonnull String[] signature, @Nullable String resultAlias) {
+    public Invocation(@Nullable String objectName, @Nonnull String operationName, @Nonnull Object[] params, @Nonnull String[] signature, @Nullable String resultAlias,
+            @Nullable Integer collectInterval) {
         try {
             this.objectName = objectName == null ? null : new ObjectName(objectName);
         } catch (MalformedObjectNameException e) {
@@ -62,9 +65,10 @@ public class Invocation {
         this.params = Preconditions2.checkNotNull(params, "params");
         this.signature = Preconditions2.checkNotNull(signature, "signature");
         this.resultAlias = resultAlias;
+        this.collectInterval = collectInterval;
     }
 
-    public void invoke(MBeanServer mbeanServer, OutputWriter outputWriter) {
+    private void invoke(MBeanServer mbeanServer, OutputWriter outputWriter) {
         Set<ObjectName> objectNames = mbeanServer.queryNames(objectName, null);
         for (ObjectName on : objectNames) {
             try {
@@ -85,5 +89,15 @@ public class Invocation {
                 ", params=" + Arrays.toString(params) +
                 ", signature=" + Arrays.toString(signature) +
                 '}';
+    }
+
+    @Override
+    public void collectAndExport(MBeanServer mbeanServer, OutputWriter outputWriter) {
+        invoke(mbeanServer, outputWriter);
+    }
+
+    @Nullable
+    public Integer getCollectIntervalOverrideOrNull() {
+        return collectInterval;
     }
 }

--- a/src/main/java/org/jmxtrans/agent/JmxTransExporterConfiguration.java
+++ b/src/main/java/org/jmxtrans/agent/JmxTransExporterConfiguration.java
@@ -68,17 +68,17 @@ public class JmxTransExporterConfiguration {
     }
 
     public JmxTransExporterConfiguration withQuery(@Nonnull String objectName, @Nonnull List<String> attributes, @Nullable String resultAlias) {
-        return withQuery(objectName, attributes, null, null, null, resultAlias);
+        return withQuery(objectName, attributes, null, null, null, resultAlias, null);
     }
 
     public JmxTransExporterConfiguration withQuery(@Nonnull String objectName, @Nonnull List<String> attributes, @Nullable String key,
-                                      @Nullable Integer position, @Nullable String type, @Nullable String resultAlias) {
-        Query query = new Query(objectName, attributes, key, position, type, resultAlias, this.resultNameStrategy);
+                                      @Nullable Integer position, @Nullable String type, @Nullable String resultAlias, @Nullable Integer collectInterval) {
+        Query query = new Query(objectName, attributes, key, position, type, resultAlias, this.resultNameStrategy, collectInterval);
         queries.add(query);
         return this;
     }
-    public JmxTransExporterConfiguration withInvocation(@Nonnull String objectName, @Nonnull String operation, @Nullable String resultAlias) {
-        invocations.add(new Invocation(objectName, operation, new Object[0], new String[0], resultAlias));
+    public JmxTransExporterConfiguration withInvocation(@Nonnull String objectName, @Nonnull String operation, @Nullable String resultAlias, @Nullable Integer collectInterval) {
+        invocations.add(new Invocation(objectName, operation, new Object[0], new String[0], resultAlias, collectInterval));
         return this;
     }
     public JmxTransExporterConfiguration withOutputWriter(OutputWriter outputWriter) {
@@ -146,4 +146,5 @@ public class JmxTransExporterConfiguration {
     public void destroy() {
         getOutputWriter().preDestroy();
     }
+
 }

--- a/src/main/java/org/jmxtrans/agent/Query.java
+++ b/src/main/java/org/jmxtrans/agent/Query.java
@@ -40,7 +40,7 @@ import java.util.logging.Level;
 /**
  * @author <a href="mailto:cleclerc@cloudbees.com">Cyrille Le Clerc</a>
  */
-public class Query {
+public class Query implements Collector {
 
     private final Logger logger = Logger.getLogger(getClass().getName());
 
@@ -79,26 +79,38 @@ public class Query {
     @Nullable
     private String type;
 
+    @Nullable
+    private Integer collectInterval;
+
     /**
      * @see #Query(String, String, String, Integer, String, String, ResultNameStrategy)
      */
     public Query(@Nonnull String objectName, @Nullable String attribute, @Nonnull ResultNameStrategy resultNameStrategy) {
-        this(objectName, attribute, null, null, null, null, resultNameStrategy);
+        this(objectName, attribute, null, null, null, null, resultNameStrategy, null);
     }
 
     /**
      * @see #Query(String, String, String, Integer, String, String, ResultNameStrategy)
      */
     public Query(@Nonnull String objectName, @Nullable String attribute, int position, @Nonnull ResultNameStrategy resultNameStrategy) {
-        this(objectName, attribute, null, position, null, null, resultNameStrategy);
+        this(objectName, attribute, null, position, null, null, resultNameStrategy, null);
     }
 
     /**
      * @see #Query(String, String, String, Integer, String, String, ResultNameStrategy)
      */
     public Query(@Nonnull String objectName, @Nullable String attribute, @Nullable String resultAlias, @Nonnull ResultNameStrategy resultNameStrategy) {
-        this(objectName, attribute, null, null, null, resultAlias, resultNameStrategy);
+        this(objectName, attribute, null, null, null, resultAlias, resultNameStrategy, null);
     }
+
+    /**
+     * Creates a Query with no collectInterval overide.
+     */
+    public Query(@Nonnull String objectName, @Nullable String attribute, @Nullable String key, @Nullable Integer position,
+                 @Nullable String type, @Nullable String resultAlias, @Nonnull ResultNameStrategy resultNameStrategy) {
+        this(objectName, attribute, key, position, type, resultAlias, resultNameStrategy, null);
+    }
+
 
     /**
      * @param objectName         The {@link ObjectName} to search for
@@ -113,9 +125,9 @@ public class Query {
      *                           {@link #collectAndExport(javax.management.MBeanServer, OutputWriter)} phase.
      */
     public Query(@Nonnull String objectName, @Nullable String attribute, @Nullable String key, @Nullable Integer position,
-                 @Nullable String type, @Nullable String resultAlias, @Nonnull ResultNameStrategy resultNameStrategy) {
+                 @Nullable String type, @Nullable String resultAlias, @Nonnull ResultNameStrategy resultNameStrategy, @Nullable Integer collectInterval) {
         this(objectName, nullOrEmtpy(attribute) ? Collections.<String>emptyList() : Collections.singletonList(attribute), key, position,
-                type, resultAlias, resultNameStrategy);
+                type, resultAlias, resultNameStrategy, collectInterval);
     }
 
     private static boolean nullOrEmtpy(String attribute) {
@@ -124,11 +136,12 @@ public class Query {
     
     /**
      * Creates a query that accepts a list of attributes to collect. If the list is empty, all attributes will be collected.
+     * @param collectInterval 
      * 
      * @see #Query(String, String, String, Integer, String, String, ResultNameStrategy)
      */
     public Query(@Nonnull String objectName, @Nonnull List<String> attributes, @Nullable String key, @Nullable Integer position,
-            @Nullable String type, @Nullable String resultAlias, @Nonnull ResultNameStrategy resultNameStrategy) {
+            @Nullable String type, @Nullable String resultAlias, @Nonnull ResultNameStrategy resultNameStrategy, @Nullable Integer collectInterval) {
         try {
             this.objectName = new ObjectName(Preconditions2.checkNotNull(objectName));
         } catch (MalformedObjectNameException e) {
@@ -140,6 +153,7 @@ public class Query {
         this.position = position;
         this.type = type;
         this.resultNameStrategy = Preconditions2.checkNotNull(resultNameStrategy, "resultNameStrategy");
+        this.collectInterval = collectInterval;
     }
 
 
@@ -299,5 +313,10 @@ public class Query {
     @Nullable
     public String getType() {
         return type;
+    }
+
+    @Nullable
+    public Integer getCollectIntervalOverrideOrNull() {
+        return collectInterval;
     }
 }

--- a/src/main/java/org/jmxtrans/agent/TimeTrackingCollector.java
+++ b/src/main/java/org/jmxtrans/agent/TimeTrackingCollector.java
@@ -47,10 +47,6 @@ public class TimeTrackingCollector {
         this.collectIntervalMillis = collectIntervalMillis;
     }
 
-    public void setCollector(Collector collector) {
-        this.collector = collector;
-    }
-
     public void collectIfEnoughTimeHasPassed(MBeanServer mbeanServer, OutputWriter outputWriter) {
         long currentMillis = currentMillis();
         if (currentMillis >= lastRun + collectIntervalMillis) {

--- a/src/main/java/org/jmxtrans/agent/TimeTrackingCollector.java
+++ b/src/main/java/org/jmxtrans/agent/TimeTrackingCollector.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) 2010-2013 the original author or authors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+ * LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ */
+package org.jmxtrans.agent;
+
+import java.util.concurrent.TimeUnit;
+
+import javax.management.MBeanServer;
+
+/**
+ * Collector that keeps track of when it was last run and which interval it needs to be run at.
+ * 
+ * @author Kristoffer Erlandsson
+ */
+public class TimeTrackingCollector {
+    private Collector collector;
+    private long lastRun = Long.MIN_VALUE;
+    private long collectIntervalMillis;
+
+    private static long currentMillis() {
+        // Use nanoTime to ensure that events such as daylight savings do not affect the duration calculation.
+        return TimeUnit.NANOSECONDS.toMillis(System.nanoTime());
+    }
+
+    public TimeTrackingCollector(Collector collector, long collectIntervalMillis) {
+        this.collector = collector;
+        this.collectIntervalMillis = collectIntervalMillis;
+    }
+
+    public void setCollector(Collector collector) {
+        this.collector = collector;
+    }
+
+    public void collectIfEnoughTimeHasPassed(MBeanServer mbeanServer, OutputWriter outputWriter) {
+        long currentMillis = currentMillis();
+        if (currentMillis >= lastRun + collectIntervalMillis) {
+            lastRun = currentMillis;
+            collector.collectAndExport(mbeanServer, outputWriter);
+        }
+    }
+
+    public long getCollectIntervalMillis() {
+        return collectIntervalMillis;
+    }
+
+}

--- a/src/main/java/org/jmxtrans/agent/util/GcdCalculator.java
+++ b/src/main/java/org/jmxtrans/agent/util/GcdCalculator.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2010-2013 the original author or authors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+ * LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ */
+package org.jmxtrans.agent.util;
+
+import java.math.BigInteger;
+import java.util.List;
+
+/**
+ * @author Kristoffer Erlandsson
+ */
+public class GcdCalculator {
+
+    /**
+     * Finds the greatest common divisor of all numbers in the list.
+     * 
+     * @Return the GCD or Long.MAX_VALUE if the list is empty.
+     */
+    public static long gcd(List<Long> l) {
+        if (l.isEmpty()) {
+            throw new IllegalArgumentException("List must contain at least one element");
+        }
+        BigInteger gcd = BigInteger.valueOf(l.get(0));
+        for (Long num : l.subList(1, l.size())) {
+            gcd = gcd.gcd(BigInteger.valueOf(num));
+        }
+        return gcd.longValue();
+        
+    }
+
+}

--- a/src/test/java/org/jmxtrans/agent/JmxTransConfigurationXmlLoaderTest.java
+++ b/src/test/java/org/jmxtrans/agent/JmxTransConfigurationXmlLoaderTest.java
@@ -202,7 +202,18 @@ public class JmxTransConfigurationXmlLoaderTest {
         JmxTransExporterConfiguration config = configLoader.build(configLoader);
         assertThat(config.getCollectInterval(), equalTo(222));
     }
-
+    
+    @Test
+    public void collectIntervalOverrideTest() throws Exception {
+        JmxTransExporterConfiguration config = new JmxTransConfigurationXmlLoader("classpath:jmxtrans-collect-interval-override-test.xml").loadConfiguration();
+        Map<String, Query> queriesByResultAlias = indexQueriesByResultAlias(config.queries);
+        assertThat(queriesByResultAlias.get("a").getCollectIntervalOverrideOrNull(), nullValue());
+        assertThat(queriesByResultAlias.get("b").getCollectIntervalOverrideOrNull(), equalTo(3));
+        Map<String, Invocation> invocationsByResultAlias = indexInvocationsByResultAlias(config.invocations);
+        assertThat(invocationsByResultAlias.get("c").getCollectIntervalOverrideOrNull(), nullValue());
+        assertThat(invocationsByResultAlias.get("d").getCollectIntervalOverrideOrNull(), equalTo(5));
+    }
+    
     Map<String, Query> indexQueriesByResultAlias(Iterable<Query> queries) {
         Map<String, Query> result = new HashMap<String, Query>();
         for (Query query : queries) {

--- a/src/test/java/org/jmxtrans/agent/QueryTest.java
+++ b/src/test/java/org/jmxtrans/agent/QueryTest.java
@@ -196,7 +196,7 @@ public class QueryTest {
     @Test
     public void attribute_list_returns_specified_attributes() throws Exception {
         Query query = new Query("test:type=Mock,name=mock", Arrays.asList("CollectionUsageThreshold", "Name"), null,
-                null, null, "altTest.#attribute#", resultNameStrategy);
+                null, null, "altTest.#attribute#", resultNameStrategy, null);
         query.collectAndExport(mbeanServer, mockOutputWriter);
         assertThat(mockOutputWriter.resultsByName.get("altTest.Name"), notNullValue());
         assertThat(mockOutputWriter.resultsByName.get("altTest.CollectionUsageThreshold"), notNullValue());
@@ -205,7 +205,7 @@ public class QueryTest {
     @Test
     public void attribute_list_attribute_does_not_return_not_specified_attribute() throws Exception {
         Query query = new Query("test:type=Mock,name=mock", Arrays.asList("CollectionUsageThreshold", "Name"), null,
-                null, null, "altTest.#attribute#", resultNameStrategy);
+                null, null, "altTest.#attribute#", resultNameStrategy, null);
         query.collectAndExport(mbeanServer, mockOutputWriter);
         assertThat(mockOutputWriter.resultsByName.get("CollectionUsageThreshold"), nullValue());
     }

--- a/src/test/java/org/jmxtrans/agent/util/GcdCalculatorTest.java
+++ b/src/test/java/org/jmxtrans/agent/util/GcdCalculatorTest.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2010-2013 the original author or authors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+ * LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ */
+package org.jmxtrans.agent.util;
+
+import static org.hamcrest.Matchers.*;
+import static org.junit.Assert.*;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+
+import org.junit.Test;
+
+/**
+ * @author Kristoffer Erlandsson
+ */
+public class GcdCalculatorTest {
+
+    @Test(expected=IllegalArgumentException.class)
+    public void emptyList() throws Exception {
+        GcdCalculator.gcd(new ArrayList<Long>());
+    }
+
+    @Test
+    public void oneNumber() throws Exception {
+        assertThat(GcdCalculator.gcd(Arrays.asList(3l)), equalTo(3l));
+    }
+
+    @Test
+    public void twoNumbers() throws Exception {
+        assertThat(GcdCalculator.gcd(Arrays.asList(9l, 3l)), equalTo(3l));
+    }
+
+    @Test
+    public void manyNumbers() throws Exception {
+        assertThat(GcdCalculator.gcd(Arrays.asList(18l, 27l, 81l, 54l)), equalTo(9l));
+    }
+    
+    @Test
+    public void primes() throws Exception {
+        assertThat(GcdCalculator.gcd(Arrays.asList(7l, 17l)), equalTo(1l));
+    }
+}

--- a/src/test/resources/jmxtrans-collect-interval-override-test.xml
+++ b/src/test/resources/jmxtrans-collect-interval-override-test.xml
@@ -1,0 +1,37 @@
+<!--
+ ~ Copyright (c) 2010-2013 the original author or authors
+ ~
+ ~ Permission is hereby granted, free of charge, to any person obtaining
+ ~ a copy of this software and associated documentation files (the
+ ~ "Software"), to deal in the Software without restriction, including
+ ~ without limitation the rights to use, copy, modify, merge, publish,
+ ~ distribute, sublicense, and/or sell copies of the Software, and to
+ ~ permit persons to whom the Software is furnished to do so, subject to
+ ~ the following conditions:
+ ~
+ ~ The above copyright notice and this permission notice shall be
+ ~ included in all copies or substantial portions of the Software.
+ ~
+ ~ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ ~ EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ ~ MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ ~ NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+ ~ LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ ~ OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ ~ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ ~
+-->
+<jmxtrans-agent>
+    <queries>
+        <query objectName="java.lang:type=Threading" attribute="ThreadCount" resultAlias="a"/>
+        <query objectName="java.lang:type=Threading" attribute="TotalStartedThreadCount" resultAlias="b"
+        collectIntervalInSeconds="3"/>
+    </queries>
+    <invocations>
+        <invocation objectName="java.lang:type=Memory" operation="gc" resultAlias="c" />
+        <invocation objectName="java.lang:type=Memory" operation="gc" resultAlias="d" collectIntervalInSeconds="5"/>
+    </invocations>
+    <outputWriter class="org.jmxtrans.agent.ConsoleOutputWriter" />
+    <reloadConfigurationCheckIntervalInSeconds>2</reloadConfigurationCheckIntervalInSeconds>
+    <collectIntervalInSeconds>20</collectIntervalInSeconds>
+</jmxtrans-agent>


### PR DESCRIPTION
Support for setting `collectIntervalInSeconds` as an attribute on queries and invocations. Overrides the default setting. For example:

```
<query objectName="java.lang:type=Threading" attributes="ThreadCount,TotalStartedThreadCount"
   resultAlias="jvm.threads.#attribute#" collectIntervalInSeconds="5"/>
```

Implementation details:
Collections are still made in a single thread. The thread is scheduled to run at an interval that is equal to the greatest common divisor of the actual collect intervals. On each run, each query/invocation is checked to see if it is time to run that specific query/invocation. The time at which it was last run is remembered to decide when to run next.

See issue #56 