### PR TITLE
Added Experimental InfluxDb output writer

### DIFF
--- a/src/main/java/org/jmxtrans/agent/GraphiteUdpOutputWriter.java
+++ b/src/main/java/org/jmxtrans/agent/GraphiteUdpOutputWriter.java
@@ -37,6 +37,8 @@ import java.util.logging.Level;
 
 import org.jmxtrans.agent.graphite.GraphiteMetricMessageBuilder;
 import org.jmxtrans.agent.util.net.HostAndPort;
+import org.jmxtrans.agent.util.time.Clock;
+import org.jmxtrans.agent.util.time.SystemCurrentTimeMillisClock;
 
 /**
  * Output writer for writing to Graphite using UDP.
@@ -69,7 +71,7 @@ public class GraphiteUdpOutputWriter extends AbstractOutputWriter {
 
     @Override
     public void writeQueryResult(String metricName, String metricType, Object value) throws IOException {
-        String msg = messageBuilder.buildMessage(metricName, value, clock.getCurrentInTimeSeconds());
+        String msg = messageBuilder.buildMessage(metricName, value, TimeUnit.SECONDS.convert(clock.getCurrentTimeMillis(), TimeUnit.MILLISECONDS));
         logMessageIfTraceLoggable(msg);
         tryWriteMsg(msg + "\n");
     }
@@ -140,15 +142,4 @@ public class GraphiteUdpOutputWriter extends AbstractOutputWriter {
         }
     }
 
-    interface Clock {
-        long getCurrentInTimeSeconds();
-    }
-
-    private static class SystemCurrentTimeMillisClock implements Clock {
-
-        @Override
-        public long getCurrentInTimeSeconds() {
-            return TimeUnit.SECONDS.convert(System.currentTimeMillis(), TimeUnit.MILLISECONDS);
-        }
-    }
 }

--- a/src/main/java/org/jmxtrans/agent/influxdb/InfluxDbOutputWriter.java
+++ b/src/main/java/org/jmxtrans/agent/influxdb/InfluxDbOutputWriter.java
@@ -41,6 +41,8 @@ import org.jmxtrans.agent.AbstractOutputWriter;
 import org.jmxtrans.agent.util.ConfigurationUtils;
 import org.jmxtrans.agent.util.io.IoRuntimeException;
 import org.jmxtrans.agent.util.io.IoUtils;
+import org.jmxtrans.agent.util.time.Clock;
+import org.jmxtrans.agent.util.time.SystemCurrentTimeMillisClock;
 
 /**
  * Output writer for InfluxDb.
@@ -139,6 +141,14 @@ public class InfluxDbOutputWriter extends AbstractOutputWriter {
 
     private void sendMetrics(String queryString, String body) throws IOException {
         HttpURLConnection conn = createAndConfigureConnection();
+        try {
+            sendMetrics(body, conn);
+        } finally {
+            IoUtils.closeQuietly(conn);
+        }
+    }
+
+    private void sendMetrics(String body, HttpURLConnection conn) throws IOException {
         writeMetrics(conn, body);
         int responseCode = conn.getResponseCode();
         if (responseCode / 100 != 2) {
@@ -205,18 +215,6 @@ public class InfluxDbOutputWriter extends AbstractOutputWriter {
             }
         }
         return sb.toString();
-    }
-
-    interface Clock {
-        long getCurrentTimeMillis();
-    }
-
-    private static class SystemCurrentTimeMillisClock implements Clock {
-
-        @Override
-        public long getCurrentTimeMillis() {
-            return System.currentTimeMillis();
-        }
     }
 
 }

--- a/src/main/java/org/jmxtrans/agent/influxdb/InfluxDbOutputWriter.java
+++ b/src/main/java/org/jmxtrans/agent/influxdb/InfluxDbOutputWriter.java
@@ -1,0 +1,222 @@
+/*
+ * Copyright (c) 2010-2016 the original author or authors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+ * LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ */
+package org.jmxtrans.agent.influxdb;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.io.UnsupportedEncodingException;
+import java.net.HttpURLConnection;
+import java.net.MalformedURLException;
+import java.net.ProtocolException;
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+
+import org.jmxtrans.agent.AbstractOutputWriter;
+import org.jmxtrans.agent.util.ConfigurationUtils;
+import org.jmxtrans.agent.util.io.IoRuntimeException;
+import org.jmxtrans.agent.util.io.IoUtils;
+
+/**
+ * Output writer for InfluxDb.
+ * 
+ * @author Kristoffer Erlandsson
+ */
+public class InfluxDbOutputWriter extends AbstractOutputWriter {
+
+    private URL url;
+    private String database;
+    private String user; // Null if not configured
+    private String password; // Null if not configured 
+    private String retentionPolicy; // Null if not configured
+    private List<InfluxTag> tags;
+    private List<InfluxMetric> batchedMetrics = new ArrayList<>();
+    private int connectTimeoutMillis;
+    private int readTimeoutMillis;
+    private final Clock clock;
+
+    public InfluxDbOutputWriter() {
+        this.clock = new SystemCurrentTimeMillisClock();
+    }
+
+    /**
+     * Test hook for supplying a fake clock.
+     */
+    InfluxDbOutputWriter(Clock clock) {
+        this.clock = clock;
+    }
+
+    @Override
+    public void postConstruct(Map<String, String> settings) {
+        String urlStr = ConfigurationUtils.getString(settings, "url");
+        database = ConfigurationUtils.getString(settings, "database");
+        user = ConfigurationUtils.getString(settings, "user", null);
+        password = ConfigurationUtils.getString(settings, "password", null);
+        retentionPolicy = ConfigurationUtils.getString(settings, "retentionPolicy", null);
+        String tagsStr = ConfigurationUtils.getString(settings, "tags", "");
+        tags = InfluxMetricConverter.tagsFromCommaSeparatedString(tagsStr);
+        connectTimeoutMillis = ConfigurationUtils.getInt(settings, "connectTimeoutMillis", 3000);
+        readTimeoutMillis = ConfigurationUtils.getInt(settings, "readTimeoutMillis", 5000);
+        url = parseUrlStr(getWriteEndpointForUrlStr(urlStr));
+        logger.log(getInfoLevel(), "InfluxDbOutputWriter is configured with url=" + urlStr
+                + ", database=" + database
+                + ", user=" + user
+                + ", password=" + (password != null ? "****" : null)
+                + ", tags=" + tagsStr
+                + ", connectTimeoutMills=" + connectTimeoutMillis
+                + ", readTimeoutMillis=" + readTimeoutMillis);
+    }
+
+    private String getWriteEndpointForUrlStr(String urlStr) {
+        return urlStr + (urlStr.endsWith("/") ? "write" : "/write");
+    }
+
+    private URL parseUrlStr(String urlStr) {
+        try {
+            return new URL(urlStr + "?" + buildQueryString());
+        } catch (MalformedURLException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private String buildQueryString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("precision=ms")
+                .append("&db=").append(database);
+        appendParamIfNotEmptyOrNull(sb, "u", user);
+        appendParamIfNotEmptyOrNull(sb, "p", password);
+        appendParamIfNotEmptyOrNull(sb, "rp", retentionPolicy);
+        return sb.toString();
+    }
+
+    @Override
+    public void writeInvocationResult(String invocationName, Object value) throws IOException {
+        writeQueryResult(invocationName, null, value);
+    }
+
+    @Override
+    public void writeQueryResult(String metricName, String metricType, Object value) throws IOException {
+        InfluxMetric metric = InfluxMetricConverter.convertToInfluxMetric(metricName, value, tags,
+                clock.getCurrentTimeMillis());
+        batchedMetrics.add(metric);
+    }
+
+    @Override
+    public void postCollect() throws IOException {
+        String body = convertMetricsToLines(batchedMetrics);
+        String queryString = buildQueryString();
+        if (logger.isLoggable(getTraceLevel())) {
+            logger.log(getTraceLevel(), "Sending to influx (" + url + "):\n" + body);
+        }
+        batchedMetrics.clear();
+        sendMetrics(queryString, body);
+    }
+
+    private void sendMetrics(String queryString, String body) throws IOException {
+        HttpURLConnection conn = createAndConfigureConnection();
+        writeMetrics(conn, body);
+        int responseCode = conn.getResponseCode();
+        if (responseCode / 100 != 2) {
+            throw new RuntimeException("Failed to write metrics, response code: " + responseCode
+                    + ", response message: " + conn.getResponseMessage());
+        }
+        String response = readResponse(conn);
+        logger.log(getTraceLevel(), "Response from influx: " + response);
+    }
+
+    private HttpURLConnection createAndConfigureConnection() throws ProtocolException {
+        HttpURLConnection conn = openHttpConnection();
+        conn.setConnectTimeout(connectTimeoutMillis);
+        conn.setReadTimeout(readTimeoutMillis);
+        conn.setDoOutput(true);
+        conn.setRequestMethod("POST");
+        return conn;
+    }
+
+    private HttpURLConnection openHttpConnection() {
+        try {
+            return (HttpURLConnection) url.openConnection();
+        } catch (IOException | ClassCastException e) {
+            throw new IoRuntimeException("Failed to create HttpURLConnection to " + url + " - is it a valid HTTP url?",
+                    e);
+        }
+    }
+
+    private void writeMetrics(HttpURLConnection conn, String body)
+            throws UnsupportedEncodingException, IOException {
+        byte[] toSendBytes = body.getBytes("UTF-8");
+        conn.setRequestProperty("Content-Length", Integer.toString(toSendBytes.length));
+        try (OutputStream os = conn.getOutputStream()) {
+            os.write(toSendBytes);
+            os.flush();
+        }
+    }
+
+    private String readResponse(HttpURLConnection conn) throws IOException, UnsupportedEncodingException {
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        try (InputStream is = conn.getInputStream()) {
+            IoUtils.copy(is, baos);
+        }
+        String response = new String(baos.toByteArray(), "UTF-8");
+        return response;
+    }
+
+    private void appendParamIfNotEmptyOrNull(StringBuilder sb, String paramName, String paramValue) {
+        if (paramValue != null && !paramValue.trim().isEmpty()) {
+            // NB: We do not URL encode anything, from what I understand from the Influx docs,
+            // encoded data is not expected.
+            sb.append("&").append(paramName).append("=").append(paramValue);
+        }
+
+    }
+
+    private String convertMetricsToLines(List<InfluxMetric> metrics) {
+        StringBuilder sb = new StringBuilder();
+        for (Iterator<InfluxMetric> it = metrics.iterator(); it.hasNext();) {
+            InfluxMetric metric = it.next();
+            sb.append(metric.toInfluxFormat());
+            if (it.hasNext()) {
+                sb.append("\n");
+            }
+        }
+        return sb.toString();
+    }
+
+    interface Clock {
+        long getCurrentTimeMillis();
+    }
+
+    private static class SystemCurrentTimeMillisClock implements Clock {
+
+        @Override
+        public long getCurrentTimeMillis() {
+            return System.currentTimeMillis();
+        }
+    }
+
+}

--- a/src/main/java/org/jmxtrans/agent/influxdb/InfluxMetric.java
+++ b/src/main/java/org/jmxtrans/agent/influxdb/InfluxMetric.java
@@ -1,0 +1,123 @@
+/*
+ * Copyright (c) 2010-2016 the original author or authors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+ * LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ */
+package org.jmxtrans.agent.influxdb;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
+import org.jmxtrans.agent.util.StringUtils2;
+
+/**
+ * @author Kristoffer Erlandsson
+ */
+public class InfluxMetric {
+
+    private static final String FIELD_NAME = "value";
+    private final long timestampMillis;
+    private final List<InfluxTag> tags;
+    private final String measurement;
+    private final Object value;
+
+    public InfluxMetric(String measurement, List<InfluxTag> tags, Object value, long timestampMillis) {
+        this.measurement = Objects.requireNonNull(measurement);
+        this.tags = Objects.requireNonNull(tags);
+        this.value = Objects.requireNonNull(value);
+        this.timestampMillis = timestampMillis;
+    }
+
+    public long getTimestampMillis() {
+        return timestampMillis;
+    }
+
+    public List<InfluxTag> getTags() {
+        return tags;
+    }
+
+    public String getMeasurement() {
+        return measurement;
+    }
+
+    public Object getValue() {
+        return valueAsStr();
+    }
+
+    public String toInfluxFormat() {
+        StringBuilder sb = new StringBuilder();
+        sb.append(measurement);
+        if (!tags.isEmpty()) {
+            sb.append(",");
+        }
+        sb.append(StringUtils2.join(convertTagsToStrings(), ","))
+                .append(" ")
+                .append(FIELD_NAME)
+                .append("=")
+                .append(valueAsStr())
+                .append(" ")
+                .append(timestampMillis);
+        return sb.toString();
+    }
+
+    private String valueAsStr() {
+        if (value instanceof Integer || value instanceof Long) {
+            return value.toString() + "i";
+        }
+        return value.toString();
+    }
+
+    private List<String> convertTagsToStrings() {
+        List<String> l = new ArrayList<>(tags.size());
+        for (InfluxTag influxTag : tags) {
+            l.add(influxTag.toInfluxFormat());
+        }
+        return l;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(timestampMillis, tags, measurement, valueAsStr());
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj)
+            return true;
+        if (obj == null)
+            return false;
+        if (getClass() != obj.getClass())
+            return false;
+        InfluxMetric other = (InfluxMetric) obj;
+        return Objects.equals(timestampMillis, other.timestampMillis)
+                && Objects.equals(tags, other.tags)
+                && Objects.equals(measurement, other.measurement)
+                && Objects.equals(valueAsStr(), other.valueAsStr());
+    }
+
+    @Override
+    public String toString() {
+        return "InfluxMetric [timestampMillis=" + timestampMillis + ", tags=" + tags + ", measurement=" + measurement
+                + ", value=" + value + "]";
+    }
+
+}

--- a/src/main/java/org/jmxtrans/agent/influxdb/InfluxMetricConverter.java
+++ b/src/main/java/org/jmxtrans/agent/influxdb/InfluxMetricConverter.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright (c) 2010-2016 the original author or authors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+ * LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ */
+package org.jmxtrans.agent.influxdb;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * @author Kristoffer Erlandsson
+ */
+public class InfluxMetricConverter {
+
+    public static InfluxMetric convertToInfluxMetric(String metricName, Object value, List<InfluxTag> additionalTags, long timestamp) {
+        List<InfluxTag> tagsFromMetricName = parseTags(metricName);
+        List<InfluxTag> allTags = new ArrayList<>(additionalTags);
+        allTags.addAll(tagsFromMetricName);
+        return new InfluxMetric(parseMeasurement(metricName), allTags, value, timestamp);
+    }
+
+    private static String parseMeasurement(String metricName) {
+        return metricName.split(",")[0].trim();
+    }
+
+    private static List<InfluxTag> parseTags(String metricName) {
+        int startOfTags = metricName.indexOf(',');
+        if (startOfTags < 0) {
+            return new ArrayList<>();
+        }
+        return tagsFromCommaSeparatedString(metricName.substring(startOfTags + 1));
+    }
+
+    public static List<InfluxTag> tagsFromCommaSeparatedString(String s) {
+        List<InfluxTag> tags = new ArrayList<>();
+        if (s.trim().isEmpty()) {
+            return tags;
+        }
+        String[] parts = s.split(",");
+        for (String tagPart : parts) {
+            tags.add(parseOneTag(tagPart));
+        }
+        return tags;
+    }
+
+    private static InfluxTag parseOneTag(String part) {
+        String[] nameAndValue = part.trim().split("=");
+        if (nameAndValue.length != 2) {
+            throw new FailedToConvertToInfluxMetricException(
+                    "Error when parsing influx tags from substring " + part + ", must be on format <name>=<value>,...");
+        }
+        InfluxTag tag = new InfluxTag(nameAndValue[0].trim(), nameAndValue[1].trim());
+        return tag;
+    }
+
+    @SuppressWarnings("serial")
+    public static class FailedToConvertToInfluxMetricException extends RuntimeException {
+
+        public FailedToConvertToInfluxMetricException(String msg) {
+            super(msg);
+        }
+
+    }
+}

--- a/src/main/java/org/jmxtrans/agent/influxdb/InfluxTag.java
+++ b/src/main/java/org/jmxtrans/agent/influxdb/InfluxTag.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright (c) 2010-2016 the original author or authors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+ * LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ */
+package org.jmxtrans.agent.influxdb;
+
+import java.util.Objects;
+
+/**
+ * @author Kristoffer Erlandsson
+ */
+public class InfluxTag {
+    private final String name;
+    private final String value;
+
+    public InfluxTag(String name, String value) {
+        this.name = Objects.requireNonNull(name);
+        this.value = Objects.requireNonNull(value);
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public String getValue() {
+        return value;
+    }
+
+    public String toInfluxFormat() {
+        return name + "=" + value;
+    }
+
+    @Override
+    public String toString() {
+        return name + "=" + value;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(name, value);
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj)
+            return true;
+        if (obj == null)
+            return false;
+        if (getClass() != obj.getClass())
+            return false;
+        InfluxTag other = (InfluxTag) obj;
+        return Objects.equals(name, other.name)
+                && Objects.equals(value, other.value);
+    }
+
+}

--- a/src/main/java/org/jmxtrans/agent/util/time/Clock.java
+++ b/src/main/java/org/jmxtrans/agent/util/time/Clock.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2010-2016 the original author or authors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+ * LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ */
+package org.jmxtrans.agent.util.time;
+
+/**
+ * @author Kristoffer Erlandsson
+ */
+public interface Clock {
+
+    long getCurrentTimeMillis();
+}

--- a/src/main/java/org/jmxtrans/agent/util/time/SystemCurrentTimeMillisClock.java
+++ b/src/main/java/org/jmxtrans/agent/util/time/SystemCurrentTimeMillisClock.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2010-2016 the original author or authors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+ * LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ */
+package org.jmxtrans.agent.util.time;
+
+/**
+ * @author Kristoffer Erlandsson
+ */
+public class SystemCurrentTimeMillisClock implements Clock {
+
+    @Override
+    public long getCurrentTimeMillis() {
+        return System.currentTimeMillis();
+    }
+}

--- a/src/test/java/org/jmxtrans/agent/influxdb/InfluxDbOutputWriterTest.java
+++ b/src/test/java/org/jmxtrans/agent/influxdb/InfluxDbOutputWriterTest.java
@@ -28,7 +28,8 @@ import static com.github.tomakehurst.wiremock.client.WireMock.*;
 import java.util.HashMap;
 import java.util.Map;
 
-import org.jmxtrans.agent.influxdb.InfluxDbOutputWriter.Clock;
+import org.jmxtrans.agent.testutils.FixedTimeClock;
+import org.jmxtrans.agent.util.time.Clock;
 import org.junit.Rule;
 import org.junit.Test;
 
@@ -39,7 +40,7 @@ import com.github.tomakehurst.wiremock.junit.WireMockRule;
  */
 public class InfluxDbOutputWriterTest {
 
-    private final static long FIXED_TIME = 1234l;
+    private final static Clock FAKE_CLOCK = new FixedTimeClock(1234l);
 
     @Rule
     public WireMockRule wireMockRule = new WireMockRule(0);
@@ -50,7 +51,7 @@ public class InfluxDbOutputWriterTest {
         s.put("url", "http://localhost:" + wireMockRule.port());
         s.put("database", "test-db");
         stubFor(post(urlPathEqualTo("/write")).willReturn(aResponse().withStatus(200)));
-        InfluxDbOutputWriter writer = new InfluxDbOutputWriter(new FakeClock());
+        InfluxDbOutputWriter writer = new InfluxDbOutputWriter(FAKE_CLOCK);
         writer.postConstruct(s);
         writer.writeQueryResult("foo", null, 1);
         writer.postCollect();
@@ -72,7 +73,7 @@ public class InfluxDbOutputWriterTest {
         s.put("connectTimeoutMillis", "1000");
         s.put("readTimeoutMillis", "5000");
         stubFor(post(urlPathEqualTo("/write")).willReturn(aResponse().withStatus(200)));
-        InfluxDbOutputWriter writer = new InfluxDbOutputWriter(new FakeClock());
+        InfluxDbOutputWriter writer = new InfluxDbOutputWriter(FAKE_CLOCK);
         writer.postConstruct(s);
         writer.writeQueryResult("foo", null, 1);
         writer.postCollect();
@@ -91,7 +92,7 @@ public class InfluxDbOutputWriterTest {
         s.put("url", "http://localhost:" + wireMockRule.port());
         s.put("database", "test-db");
         stubFor(post(urlPathEqualTo("/write")).willReturn(aResponse().withStatus(200)));
-        InfluxDbOutputWriter writer = new InfluxDbOutputWriter(new FakeClock());
+        InfluxDbOutputWriter writer = new InfluxDbOutputWriter(FAKE_CLOCK);
         writer.postConstruct(s);
         writer.writeQueryResult("foo,tag=tagValue", null, 1);
         writer.postCollect();
@@ -107,7 +108,7 @@ public class InfluxDbOutputWriterTest {
         s.put("url", "http://localhost:" + wireMockRule.port());
         s.put("database", "test-db");
         stubFor(post(urlPathEqualTo("/write")).willReturn(aResponse().withStatus(200)));
-        InfluxDbOutputWriter writer = new InfluxDbOutputWriter(new FakeClock());
+        InfluxDbOutputWriter writer = new InfluxDbOutputWriter(FAKE_CLOCK);
         writer.postConstruct(s);
         writer.writeQueryResult("foo", null, 1);
         writer.writeQueryResult("foo2", null, 2.0);
@@ -118,12 +119,4 @@ public class InfluxDbOutputWriterTest {
                 .withRequestBody(equalTo("foo value=1i 1234\nfoo2 value=2.0 1234")));
     }
 
-    private static class FakeClock implements Clock {
-
-        @Override
-        public long getCurrentTimeMillis() {
-            return FIXED_TIME;
-        }
-
-    }
 }

--- a/src/test/java/org/jmxtrans/agent/influxdb/InfluxDbOutputWriterTest.java
+++ b/src/test/java/org/jmxtrans/agent/influxdb/InfluxDbOutputWriterTest.java
@@ -1,0 +1,129 @@
+/*
+ * Copyright (c) 2010-2016 the original author or authors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+ * LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ */
+package org.jmxtrans.agent.influxdb;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.*;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.jmxtrans.agent.influxdb.InfluxDbOutputWriter.Clock;
+import org.junit.Rule;
+import org.junit.Test;
+
+import com.github.tomakehurst.wiremock.junit.WireMockRule;
+
+/**
+ * @author Kristoffer Erlandsson
+ */
+public class InfluxDbOutputWriterTest {
+
+    private final static long FIXED_TIME = 1234l;
+
+    @Rule
+    public WireMockRule wireMockRule = new WireMockRule(0);
+
+    @Test
+    public void simpleRequest() throws Exception {
+        Map<String, String> s = new HashMap<>();
+        s.put("url", "http://localhost:" + wireMockRule.port());
+        s.put("database", "test-db");
+        stubFor(post(urlPathEqualTo("/write")).willReturn(aResponse().withStatus(200)));
+        InfluxDbOutputWriter writer = new InfluxDbOutputWriter(new FakeClock());
+        writer.postConstruct(s);
+        writer.writeQueryResult("foo", null, 1);
+        writer.postCollect();
+        verify(postRequestedFor(urlPathEqualTo("/write"))
+                .withQueryParam("db", equalTo("test-db"))
+                .withQueryParam("precision", equalTo("ms"))
+                .withRequestBody(equalTo("foo value=1i 1234")));
+    }
+
+    @Test
+    public void allConfigParameters() throws Exception {
+        Map<String, String> s = new HashMap<>();
+        s.put("url", "http://localhost:" + wireMockRule.port());
+        s.put("database", "test-db");
+        s.put("retentionPolicy", "policy");
+        s.put("user", "admin");
+        s.put("password", "shadow");
+        s.put("tags", "t1=v1,t2=v2");
+        s.put("connectTimeoutMillis", "1000");
+        s.put("readTimeoutMillis", "5000");
+        stubFor(post(urlPathEqualTo("/write")).willReturn(aResponse().withStatus(200)));
+        InfluxDbOutputWriter writer = new InfluxDbOutputWriter(new FakeClock());
+        writer.postConstruct(s);
+        writer.writeQueryResult("foo", null, 1);
+        writer.postCollect();
+        verify(postRequestedFor(urlPathEqualTo("/write"))
+                .withQueryParam("db", equalTo("test-db"))
+                .withQueryParam("precision", equalTo("ms"))
+                .withQueryParam("rp", equalTo("policy"))
+                .withQueryParam("u", equalTo("admin"))
+                .withQueryParam("p", equalTo("shadow"))
+                .withRequestBody(equalTo("foo,t1=v1,t2=v2 value=1i 1234")));
+    }
+
+    @Test
+    public void tagsInMetricName() throws Exception {
+        Map<String, String> s = new HashMap<>();
+        s.put("url", "http://localhost:" + wireMockRule.port());
+        s.put("database", "test-db");
+        stubFor(post(urlPathEqualTo("/write")).willReturn(aResponse().withStatus(200)));
+        InfluxDbOutputWriter writer = new InfluxDbOutputWriter(new FakeClock());
+        writer.postConstruct(s);
+        writer.writeQueryResult("foo,tag=tagValue", null, 1);
+        writer.postCollect();
+        verify(postRequestedFor(urlPathEqualTo("/write"))
+                .withQueryParam("db", equalTo("test-db"))
+                .withQueryParam("precision", equalTo("ms"))
+                .withRequestBody(equalTo("foo,tag=tagValue value=1i 1234")));
+    }
+
+    @Test
+    public void manyMetrics() throws Exception {
+        Map<String, String> s = new HashMap<>();
+        s.put("url", "http://localhost:" + wireMockRule.port());
+        s.put("database", "test-db");
+        stubFor(post(urlPathEqualTo("/write")).willReturn(aResponse().withStatus(200)));
+        InfluxDbOutputWriter writer = new InfluxDbOutputWriter(new FakeClock());
+        writer.postConstruct(s);
+        writer.writeQueryResult("foo", null, 1);
+        writer.writeQueryResult("foo2", null, 2.0);
+        writer.postCollect();
+        verify(postRequestedFor(urlPathEqualTo("/write"))
+                .withQueryParam("db", equalTo("test-db"))
+                .withQueryParam("precision", equalTo("ms"))
+                .withRequestBody(equalTo("foo value=1i 1234\nfoo2 value=2.0 1234")));
+    }
+
+    private static class FakeClock implements Clock {
+
+        @Override
+        public long getCurrentTimeMillis() {
+            return FIXED_TIME;
+        }
+
+    }
+}

--- a/src/test/java/org/jmxtrans/agent/influxdb/InfluxMetricConverterTest.java
+++ b/src/test/java/org/jmxtrans/agent/influxdb/InfluxMetricConverterTest.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright (c) 2010-2016 the original author or authors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+ * LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ */
+package org.jmxtrans.agent.influxdb;
+
+import static org.hamcrest.Matchers.*;
+import static org.junit.Assert.*;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+
+import org.junit.Test;
+
+/**
+ * @author Kristoffer Erlandsson
+ */
+public class InfluxMetricConverterTest {
+
+    private static final ArrayList<InfluxTag> EMPTY_TAG_LIST = new ArrayList<InfluxTag>();
+
+    @Test
+    public void noExtraTags() throws Exception {
+        InfluxMetric converted = InfluxMetricConverter.convertToInfluxMetric("foo", 1, EMPTY_TAG_LIST, 2l);
+        InfluxMetric expected = new InfluxMetric("foo", EMPTY_TAG_LIST, 1, 2l);
+        assertThat(converted, equalTo(expected));
+    }
+
+    @Test
+    public void tagsInMetricName() throws Exception {
+        InfluxMetric converted = InfluxMetricConverter.convertToInfluxMetric("foo,tag1=tagValue1", 1, EMPTY_TAG_LIST, 2l);
+        InfluxMetric expected = new InfluxMetric("foo", Arrays.asList(new InfluxTag("tag1", "tagValue1")), 1, 2l);
+        assertThat(converted, equalTo(expected));
+    }
+
+    @Test
+    public void tagsWithSpacesInMetricName() throws Exception {
+        InfluxMetric converted = InfluxMetricConverter.convertToInfluxMetric("foo,tag1 =tagValue1 , tag2 = tagValue2",
+                1, EMPTY_TAG_LIST, 2l);
+        InfluxMetric expected = new InfluxMetric("foo",
+                Arrays.asList(new InfluxTag("tag1", "tagValue1"), new InfluxTag("tag2", "tagValue2")), 1, 2l);
+        assertThat(converted, equalTo(expected));
+    }
+
+    @Test
+    public void additionalTags() throws Exception {
+        InfluxMetric converted = InfluxMetricConverter.convertToInfluxMetric("foo,tag1=tagValue1", 1,
+                Arrays.asList(new InfluxTag("additionalTag", "value")), 2l);
+        InfluxMetric expected = new InfluxMetric("foo",
+                Arrays.asList(new InfluxTag("additionalTag", "value"), new InfluxTag("tag1", "tagValue1")), 1, 2l);
+        assertThat(converted, equalTo(expected));
+    }
+
+    @Test
+    public void toInfluxFormat() throws Exception {
+        InfluxMetric metric = new InfluxMetric("foo",
+                Arrays.asList(new InfluxTag("tag", "value"), new InfluxTag("tag2", "value2")), 1.0, 2123l);
+        assertThat(metric.toInfluxFormat(), equalTo("foo,tag=value,tag2=value2 value=1.0 2123"));
+    }
+
+    @Test
+    public void toInfluxFormatInteger() throws Exception {
+        InfluxMetric metric = new InfluxMetric("foo", EMPTY_TAG_LIST, 1, 2123l);
+        assertThat(metric.toInfluxFormat(), equalTo("foo value=1i 2123"));
+    }
+
+    @Test
+    public void toInfluxFormatLong() throws Exception {
+        InfluxMetric metric = new InfluxMetric("foo", EMPTY_TAG_LIST, 1l, 2123l);
+        assertThat(metric.toInfluxFormat(), equalTo("foo value=1i 2123"));
+    }
+}

--- a/src/test/java/org/jmxtrans/agent/testutils/FixedTimeClock.java
+++ b/src/test/java/org/jmxtrans/agent/testutils/FixedTimeClock.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2010-2016 the original author or authors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+ * LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ */
+package org.jmxtrans.agent.testutils;
+
+import org.jmxtrans.agent.util.time.Clock;
+
+/**
+ * @author Kristoffer Erlandsson
+ */
+public class FixedTimeClock implements Clock {
+    
+    private final long fixedTime;
+    
+    public FixedTimeClock(long fixedTime) {
+        this.fixedTime = fixedTime;
+    }
+
+    @Override
+    public long getCurrentTimeMillis() {
+        return fixedTime;
+    }
+
+}


### PR DESCRIPTION
Output writer for InfluxDb.

A bit experimental since I'm not an Influx expert. However, the changes do not affect anything else so should be safe to merge and let others test it.

Restricted to measurements with one field since I could not come up with a good way to support multiple fields with how we structure queries and writers.

For more information about configuration and how it works see the updated README.md.

@cyrille-leclerc If you have the time, I would appreciate a review.

Fixes #24 