### PR TITLE
Add seconds/milliseconds to timestamps

### DIFF
--- a/src/main/java/org/jmxtrans/agent/FileOverwriterOutputWriter.java
+++ b/src/main/java/org/jmxtrans/agent/FileOverwriterOutputWriter.java
@@ -52,8 +52,7 @@ public class FileOverwriterOutputWriter extends AbstractOutputWriter {
     protected File temporaryFile;
     protected File file = new File(SETTING_FILE_NAME_DEFAULT_VALUE);
     protected Boolean showTimeStamp;
-    private static Calendar cal = Calendar.getInstance(TimeZone.getTimeZone("GMT"));
-    private static DateFormat dfISO8601 = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm'Z'");
+    private static DateFormat dfISO8601 = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'");
     
     @Override
     public synchronized void postConstruct(Map<String, String> settings) {

--- a/src/main/java/org/jmxtrans/agent/RollingFileOutputWriter.java
+++ b/src/main/java/org/jmxtrans/agent/RollingFileOutputWriter.java
@@ -49,7 +49,7 @@ public class RollingFileOutputWriter extends AbstractOutputWriter {
     public final static long SETTING_MAX_FILE_SIZE_DEFAULT_VALUE=10;
     public final static String SETTING_MAX_BACKUP_INDEX = "maxBackupIndex";
     public final static int SETTING_MAX_BACKUP_INDEX_DEFAULT_VALUE = 5; 
-    private static DateFormat dfISO8601 = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm'Z'");
+    private static DateFormat dfISO8601 = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'");
     
     protected Writer temporaryFileWriter;
     protected File temporaryFile;


### PR DESCRIPTION
Rationale: the current default logging interval is already in seconds.