### PR TITLE
Added ability to disable the InfluxDbOutputWriter

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -87,9 +87,10 @@
     <dependency>
       <groupId>com.github.tomakehurst</groupId>
       <artifactId>wiremock</artifactId>
-      <version>1.58</version>
+      <version>2.5.1</version>
       <scope>test</scope>
     </dependency>
+
   </dependencies>
   <build>
     <plugins>

--- a/src/test/java/org/jmxtrans/agent/influxdb/InfluxDbOutputWriterTest.java
+++ b/src/test/java/org/jmxtrans/agent/influxdb/InfluxDbOutputWriterTest.java
@@ -125,11 +125,11 @@ public class InfluxDbOutputWriterTest {
         s.put("url", "http://localhost:" + wireMockRule.port());
         s.put("database", "test-db");
         s.put("enabled", "false");
-        verify(exactly(0), getRequestedFor(urlEqualTo("/write")));
         InfluxDbOutputWriter writer = new InfluxDbOutputWriter(FAKE_CLOCK);
         writer.postConstruct(s);
         writer.writeQueryResult("foo", null, 1);
         writer.postCollect();
+        verify(exactly(0), getRequestedFor(urlEqualTo("/write")));
     }
 
     @Test

--- a/src/test/java/org/jmxtrans/agent/influxdb/InfluxDbOutputWriterTest.java
+++ b/src/test/java/org/jmxtrans/agent/influxdb/InfluxDbOutputWriterTest.java
@@ -125,12 +125,7 @@ public class InfluxDbOutputWriterTest {
         s.put("url", "http://localhost:" + wireMockRule.port());
         s.put("database", "test-db");
         s.put("enabled", "false");
-        // NOTE: This is a workaround as I didn't see a clean method to assert that Wiremocks is not called.
-        stubFor(any(urlPathEqualTo("/write"))
-                .atPriority(10)
-                .willReturn(aResponse()
-                        .withStatus(404)
-                        .withBody("{\"status\":\"Error\",\"message\":\"Should not be called\"}")));
+        verify(exactly(0), getRequestedFor(urlEqualTo("/write")));
         InfluxDbOutputWriter writer = new InfluxDbOutputWriter(FAKE_CLOCK);
         writer.postConstruct(s);
         writer.writeQueryResult("foo", null, 1);


### PR DESCRIPTION
This pull request provides the ability to disable the InfluxDbOutputWriter like its Graphite brethren.