### PR TITLE
[#84] configurable output for logger: stdout or stderr. 

### DIFF
--- a/src/main/java/org/jmxtrans/agent/JmxTransAgent.java
+++ b/src/main/java/org/jmxtrans/agent/JmxTransAgent.java
@@ -87,7 +87,7 @@ public class JmxTransAgent {
     }
 
     public static void main(String[] args) {
-        System.out.println(getVersionInfo());
+        Logger.out.println(getVersionInfo());
     }
 
     /**
@@ -153,10 +153,10 @@ public class JmxTransAgent {
                 while (JmxTransAgent.DIAGNOSTIC) {
 
                     String prefix = new Timestamp(System.currentTimeMillis()) + " [jmxtrans-agent] ";
-                    System.out.println(prefix + "JMXTRANS-AGENT DIAGNOSTIC INFO");
+                    Logger.out.println(prefix + "JMXTRANS-AGENT DIAGNOSTIC INFO");
 
                     // CONTEXT
-                    System.out.println(prefix + "Logger level: " + Logger.level);
+                    Logger.out.println(prefix + "Logger level: " + Logger.level);
 
                     // MBEANS
                     Set<ObjectInstance> objectInstances = ManagementFactory.getPlatformMBeanServer().queryMBeans(null, null);
@@ -165,12 +165,12 @@ public class JmxTransAgent {
                         objectNames.add(objectInstance.getObjectName());
                     }
                     Collections.sort(objectNames);
-                    System.out.println(prefix + "ManagementFactory.getPlatformMBeanServer().queryMBeans(null, null)");
+                    Logger.out.println(prefix + "ManagementFactory.getPlatformMBeanServer().queryMBeans(null, null)");
                     for (ObjectName objectName : objectNames) {
-                        System.out.println(prefix + "\t" + objectName);
+                        Logger.out.println(prefix + "\t" + objectName);
                     }
 
-                    System.out.println(prefix + "ENF OF JMXTRANS-AGENT DIAGNOSING INFO");
+                    Logger.out.println(prefix + "ENF OF JMXTRANS-AGENT DIAGNOSING INFO");
                     try {
                         Thread.sleep(TimeUnit.MILLISECONDS.convert(60, TimeUnit.SECONDS));
                     } catch (InterruptedException e) {

--- a/src/main/java/org/jmxtrans/agent/util/logging/Logger.java
+++ b/src/main/java/org/jmxtrans/agent/util/logging/Logger.java
@@ -24,8 +24,11 @@
 package org.jmxtrans.agent.util.logging;
 
 import edu.umd.cs.findbugs.annotations.*;
+import org.jmxtrans.agent.JmxTransAgent;
 
 import javax.annotation.Nullable;
+
+import java.io.PrintStream;
 import java.sql.Timestamp;
 import java.util.HashMap;
 import java.util.Map;
@@ -41,6 +44,18 @@ public class Logger {
     }
 
     private final String name;
+
+    @SuppressFBWarnings("MS_SHOULD_BE_REFACTORED_TO_BE_FINAL")
+    public static PrintStream out;
+
+    static {
+        if ("stderr".equalsIgnoreCase(System.getenv("JMX_TRANS_AGENT_CONSOLE")) ||
+                "stderr".equalsIgnoreCase(System.getProperty(Logger.class.getName() + ".console"))) {
+            Logger.out = System.err;
+        } else {
+            Logger.out = System.out;
+        }
+    }
 
     @SuppressFBWarnings("MS_SHOULD_BE_REFACTORED_TO_BE_FINAL")
     public static Level level = Level.INFO;
@@ -87,9 +102,9 @@ public class Logger {
         if (!isLoggable(level)) {
             return;
         }
-        System.out.println(new Timestamp(System.currentTimeMillis()) + " " + level + " [" + Thread.currentThread().getName() + "] " + name + " - " + msg);
+        Logger.out.println(new Timestamp(System.currentTimeMillis()) + " " + level + " [" + Thread.currentThread().getName() + "] " + name + " - " + msg);
         if (thrown != null) {
-            thrown.printStackTrace(System.out);
+            thrown.printStackTrace(Logger.out);
         }
     }
 


### PR DESCRIPTION
#84 configurable output for logger: stdout or stderr. 
Use the environment variable `JMX_TRANS_AGENT_CONSOLE=stderr` or the system property `-Dorg.jmxtrans.agent.util.logging.Logger.console=stderr`