### PR TITLE
Fix #98 purge ByteBuffer in case of exceptions sending the message

### DIFF
--- a/src/main/java/org/jmxtrans/agent/StatsDOutputWriter.java
+++ b/src/main/java/org/jmxtrans/agent/StatsDOutputWriter.java
@@ -32,6 +32,7 @@ import java.io.IOException;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.net.UnknownHostException;
+import java.nio.BufferOverflowException;
 import java.nio.ByteBuffer;
 import java.nio.channels.DatagramChannel;
 import java.util.Map;
@@ -167,11 +168,12 @@ public class StatsDOutputWriter extends AbstractOutputWriter implements OutputWr
                         address.getHostName(), address.getPort(), nbSentBytes, sizeOfBuffer));
                 return false;
             }
-        } catch (IOException e) {
+        } catch (IOException | RuntimeException e) { // RuntimeException can by BufferOverflowException...
             addressReference.purge();
             logger.log(Level.SEVERE,
                     String.format("Could not send stat %s to host %s:%d", sendBuffer.toString(), address.getHostName(),
                             address.getPort()), e);
+            sendBuffer.clear();
             return false;
         }
     }

--- a/src/test/java/org/jmxtrans/agent/StatsDOutputWriterTest.java
+++ b/src/test/java/org/jmxtrans/agent/StatsDOutputWriterTest.java
@@ -61,6 +61,23 @@ public class StatsDOutputWriterTest {
 
     }
 
+    /**
+     * https://github.com/jmxtrans/jmxtrans-agent/issues/98
+     */
+    @Test
+    public void test_BufferOverflowException() throws IOException {
+        StatsDOutputWriter writer = new StatsDOutputWriter();
+        Map<String, String> config = new HashMap<>();
+        config.put(StatsDOutputWriter.SETTING_HOST, "host-does-not-exist.local");
+        config.put(StatsDOutputWriter.SETTING_PORT, "8125");
+        config.put(StatsDOutputWriter.SETTING_ROOT_PREFIX, "");
+
+        writer.postConstruct(config);
+
+        for (int i = 0; i < 100; i++) {
+            writer.writeQueryResult("the.answer", "counter", i);
+        }
+    }
     public class StatsDOutputWriterMock extends StatsDOutputWriter {
         public String receivedStat;
 


### PR DESCRIPTION
Fix #98 Purge ByteBuffer in case of exceptions sending the message + extend exception catching to RuntimeException