### PR TITLE
String values surrounded in double-quotes. Special characters escaped.

### DIFF
--- a/src/main/java/org/jmxtrans/agent/influxdb/InfluxMetric.java
+++ b/src/main/java/org/jmxtrans/agent/influxdb/InfluxMetric.java
@@ -105,7 +105,8 @@ public class InfluxMetric {
                 return NUMBER_FORMAT.format(value);
             }
         }
-        return value.toString();
+        String s = value.toString();
+        return "\""+ s.replace("\\", "\\\\").replace("\"","\\\"") +"\"";
     }
 
     private List<String> convertTagsToStrings() {

--- a/src/test/java/org/jmxtrans/agent/influxdb/InfluxMetricTest.java
+++ b/src/test/java/org/jmxtrans/agent/influxdb/InfluxMetricTest.java
@@ -1,0 +1,23 @@
+package org.jmxtrans.agent.influxdb;
+
+import static org.junit.Assert.*;
+
+import java.util.Collections;
+import java.util.List;
+
+import org.junit.Test;
+
+public class InfluxMetricTest {
+
+    private static final String NOTNULL = "";
+    private static final List<InfluxTag> NOTNULLLIST = Collections.emptyList();
+    
+
+    @Test
+    public void testGetValue() {
+        assertEquals("\"simple\"", new InfluxMetric(NOTNULL, NOTNULLLIST, "simple", 0).getValue());
+        assertEquals("\"\\\"quoted\\\"\"", new InfluxMetric(NOTNULL, NOTNULLLIST, "\"quoted\"", 0).getValue());
+        assertEquals("\"multi\\\\nline\"", new InfluxMetric(NOTNULL, NOTNULLLIST, "multi\\nline", 0).getValue());
+    }
+
+}


### PR DESCRIPTION
> All string values must be surrounded in double-quotes ". If the string contains a double-quote or backslashes, it must be escaped with a backslash, e.g. \", \\

https://github.com/influxdata/influxdb/blob/master/tsdb/README.md#fields