### PR TITLE
Convert Boolean attribute into int metrics

### DIFF
--- a/src/main/java/org/jmxtrans/agent/graphite/GraphiteMetricMessageBuilder.java
+++ b/src/main/java/org/jmxtrans/agent/graphite/GraphiteMetricMessageBuilder.java
@@ -50,6 +50,9 @@ public class GraphiteMetricMessageBuilder {
      * @return The metric string without trailing newline
      */
     public String buildMessage(String metricName, Object value, long timestamp) {
+        if (value instanceof Boolean) {
+            return metricPathPrefix + metricName + " " + ((Boolean)value ? 1 : 0) + " " + timestamp;
+        }
         return metricPathPrefix + metricName + " " + value + " " + timestamp;
     }
     

--- a/src/test/java/org/jmxtrans/agent/GraphiteMetricMessageBuilderTest.java
+++ b/src/test/java/org/jmxtrans/agent/GraphiteMetricMessageBuilderTest.java
@@ -48,5 +48,18 @@ public class GraphiteMetricMessageBuilderTest {
         assertThat(msg, startsWith("servers."));
         assertThat(msg, endsWith(" 2 11"));
     }
+    
+    @Test
+    public void trueIsConvertedToOne() {
+        GraphiteMetricMessageBuilder builder = new GraphiteMetricMessageBuilder("foo.");
+        String msg = builder.buildMessage("bar", true, 11);
+        assertThat(msg, equalTo("foo.bar 1 11"));
+    }
 
+    @Test
+    public void falseIsConvertedToZero() {
+        GraphiteMetricMessageBuilder builder = new GraphiteMetricMessageBuilder("foo.");
+        String msg = builder.buildMessage("bar", false, 11);
+        assertThat(msg, equalTo("foo.bar 0 11"));
+    }
 }


### PR DESCRIPTION
Graphite only supports numeric values. It is useful to be able to publish boolean attributes as binary metrics as sometimes we do not own the code that exposes those attributes. 

This is a feature that is already supported by [jmxtrans](https://github.com/jmxtrans/jmxtrans/issues/99).

Apologies for the currently required disclaimer below! :)

This contribution is provided 'as is' and without any warranty or guarantee of any kind, express or implied, including in relation to its quality, suitability for a particular purpose or non-infringement. To the extent permitted by law, in no event shall the creator of this contribution be liable for any claim, damage or other liability, whether arising in contract, tort or otherwise, arising out of or in connection with this contribution.
