### PR TITLE
Add option for waiting for an MBeanServer as opposed to flat delay

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ export JAVA_OPTS="$JAVA_OPTS -javaagent:/path/to/jmxtrans-agent-1.2.4.jar=jmxtra
 
 For some application servers like JBoss, delaying premain is needed to start the agent, see [WFLY-3054](https://issues.jboss.org/browse/WFLY-3054)
 This has been confirmed to be needed with JBoss 5.x, 6.x, 7.x and Wildfly 8.x. This is because a
-custom MBeanServer is used by programmatically setting the ["javax.management.builder.initial"
+custom `MBeanServer` is used by programmatically setting the ["javax.management.builder.initial"
 system property](https://docs.oracle.com/javase/9/docs/api/javax/management/MBeanServerFactory.html)
 in JBoss's startup sequence. If the `PlatformMBeanServer` is initialized before this is set, the
 `PlatformMBeanServer` will not use the implementation JBoss expects.

--- a/README.md
+++ b/README.md
@@ -33,17 +33,17 @@ system property](https://docs.oracle.com/javase/9/docs/api/javax/management/MBea
 in JBoss's startup sequence. If the `PlatformMBeanServer` is initialized before this is set, the
 `PlatformMBeanServer` will not use the implementation JBoss expects.
 
-To wait for the custom MBeanServer to be defined (version >= 1.2.8):
+For versions >=1.2.8, you can wait for the custom MBeanServer to be defined, set `jmxtrans.agent.premain.waitForCustomMBeanServer=true`:
 
 ```
-# delays calling premain() in jmxtrans agent until javax.management.builder.initial is set up to 2 minutes
+# delays calling premain() in jmxtrans agent until javax.management.builder.initial is set, up to 2 minutes
 java -Djmxtrans.agent.premain.waitForCustomMBeanServer=true
 ```
 
-You can optionally increase the timeout to wait if necessary (defaults to 2 minutes):
+This usually takes less than a second. If needed, you can optionally increase the timeout to wait by setting `jmxtrans.agent.premain.waitForCustomMBeanServer.timeoutInSeconds` (defaults to 2 minutes):
 
 ```
-# delays calling premain() in jmxtrans agent until javax.management.builder.initial is set up to 5 minutes
+# delays calling premain() in jmxtrans agent until javax.management.builder.initial is set, up to 5 minutes
 java -Djmxtrans.agent.premain.waitForCustomMBeanServer=true -Djmxtrans.agent.premain.waitForCustomMBeanServer.timeoutInSeconds=300
 ```
 

--- a/README.md
+++ b/README.md
@@ -24,11 +24,6 @@ export JAVA_OPTS="$JAVA_OPTS -javaagent:/path/to/jmxtrans-agent-1.2.4.jar=jmxtra
 * java agent jar path can be relative to the working dir
 * `jmxtrans-agent.xml` is the configuration file, can be classpath relative (`classpath:…`), http(s) (`http(s)://...`) or file system based (relative to the working dir)
 
-### Custom MBeanServers (version >= 1.2.8)
-
-JMX allows custom MBeanServers to be used by defining a ["javax.management.builder.initial" system property](https://docs.oracle.com/javase/9/docs/api/javax/management/MBeanServerFactory.html).
-If an MBeanServer is created before this is set,
-
 ### Delayed startup (version >= 1.2.1)
 
 For some application servers like JBoss, delaying premain is needed to start the agent, see [WFLY-3054](https://issues.jboss.org/browse/WFLY-3054)

--- a/src/main/java/org/jmxtrans/agent/JmxTransAgent.java
+++ b/src/main/java/org/jmxtrans/agent/JmxTransAgent.java
@@ -223,7 +223,7 @@ public class JmxTransAgent {
     private static boolean waitForMBeanServer(int timeoutSeconds) {
         long start = System.currentTimeMillis();
 
-        while (!isMBeanServerCreated() && msSince(start) < (timeoutSeconds * 1000)) {
+        while (!isMBeanServerCreated() && secondsSince(start) < timeoutSeconds) {
             try {
                 Thread.sleep(1000);
             } catch (InterruptedException e) {
@@ -232,7 +232,7 @@ public class JmxTransAgent {
             }
         }
 
-        if (msSince(start) >= timeoutSeconds) {
+        if (secondsSince(start) >= timeoutSeconds) {
             logger.info("jmxagent initialization timed out waiting for MBeanServer");
             return false;
         }
@@ -244,7 +244,7 @@ public class JmxTransAgent {
         return MBeanServerFactory.findMBeanServer(null).size() > 0;
     }
 
-    private static long msSince(long startMillis) {
-        return System.currentTimeMillis() - startMillis;
+    private static long secondsSince(long startMillis) {
+        return (System.currentTimeMillis() - startMillis) / 1000;
     }
 }

--- a/src/main/java/org/jmxtrans/agent/JmxTransAgent.java
+++ b/src/main/java/org/jmxtrans/agent/JmxTransAgent.java
@@ -70,7 +70,7 @@ public class JmxTransAgent {
         final int delayInSecs = Integer.parseInt(System.getProperty("jmxtrans.agent.premain.delay", "0"));
         final boolean waitForMBeanServer =
             Boolean.parseBoolean(System.getProperty("jmxtrans.agent.premain.waitForMBeanServer"));
-        final int timeout = Integer.parseInt(
+        final int timeoutInSeconds = Integer.parseInt(
             System.getProperty("jmxtrans.agent.premain.waitForMBeanServer.timeoutInSeconds", "120"));
 
         if (delayInSecs > 0) {
@@ -86,7 +86,7 @@ public class JmxTransAgent {
                     }
 
                     if (waitForMBeanServer) {
-                        if (!waitForMBeanServer(timeout)) {
+                        if (!waitForMBeanServer(timeoutInSeconds)) {
                             return;
                         }
                     }
@@ -99,7 +99,7 @@ public class JmxTransAgent {
             new Thread("jmxtrans-agent-delayed-starter-waitForMBeanServer") {
                 @Override
                 public void run() {
-                    if (!waitForMBeanServer(timeout)) {
+                    if (!waitForMBeanServer(timeoutInSeconds)) {
                         return;
                     }
 
@@ -214,16 +214,16 @@ public class JmxTransAgent {
 
     /**
      * Polls every second to see if any {@link javax.management.MBeanServer} have been created
-     * by another thread up to {@code timeoutMillis}. If interrupted or timed out, returns
+     * by another thread up to {@code timeoutInSeconds}. If interrupted or timed out, returns
      * {@code false}.
-     * @param timeoutSeconds Maximum number of seconds to wait before giving up.
-     * @return {@code true} if found an {@code MBeanServer} within {@code timeoutSeconds}.
+     * @param timeoutInSeconds Maximum number of seconds to wait before giving up.
+     * @return {@code true} if found an {@code MBeanServer} within {@code timeoutInSeconds}.
      * {@code false} otherwise.
      */
-    private static boolean waitForMBeanServer(int timeoutSeconds) {
-        long start = System.currentTimeMillis();
+    private static boolean waitForMBeanServer(int timeoutInSeconds) {
+        long startInMs = System.currentTimeMillis();
 
-        while (!isMBeanServerCreated() && secondsSince(start) < timeoutSeconds) {
+        while (!isMBeanServerCreated() && secondsSince(startInMs) < timeoutInSeconds) {
             try {
                 Thread.sleep(1000);
             } catch (InterruptedException e) {
@@ -232,7 +232,7 @@ public class JmxTransAgent {
             }
         }
 
-        if (secondsSince(start) >= timeoutSeconds) {
+        if (secondsSince(startInMs) >= timeoutInSeconds) {
             logger.info("jmxagent initialization timed out waiting for MBeanServer");
             return false;
         }
@@ -244,7 +244,7 @@ public class JmxTransAgent {
         return MBeanServerFactory.findMBeanServer(null).size() > 0;
     }
 
-    private static long secondsSince(long startMillis) {
-        return (System.currentTimeMillis() - startMillis) / 1000;
+    private static long secondsSince(long startInMs) {
+        return (System.currentTimeMillis() - startInMs) / 1000;
     }
 }

--- a/src/main/java/org/jmxtrans/agent/JmxTransAgent.java
+++ b/src/main/java/org/jmxtrans/agent/JmxTransAgent.java
@@ -23,7 +23,6 @@
  */
 package org.jmxtrans.agent;
 
-import com.sun.jmx.defaults.JmxProperties;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 import org.jmxtrans.agent.properties.NoPropertiesSourcePropertiesLoader;
@@ -244,7 +243,7 @@ public class JmxTransAgent {
 
     /** @see javax.management.MBeanServerFactory */
     static private boolean isCustomMBeanServerConfigured() {
-        return System.getProperty(JmxProperties.JMX_INITIAL_BUILDER) != null;
+        return System.getProperty("javax.management.builder.initial") != null;
     }
 
     private static long secondsSince(long startInMs) {


### PR DESCRIPTION
This should be a little more stable and faster than a flat delay.

Let me know what you think and I can try and add a test for it.

Tested with EAP7:

```
2017-12-02 19:30:44.76 INFO [main] org.jmxtrans.agent.JmxTransAgent - jmxtrans agent initialization delayed waiting for MBeanServer
19:30:45,056 INFO  [org.jboss.modules] (main) JBoss Modules version 1.6.0.Final-redhat-1
2017-12-02 19:30:45.768 INFO [jmxtrans-agent-delayed-starter-waitForMBeanServer] org.jmxtrans.agent.JmxTransAgent - Starting 'JMX metrics exporter agent: 1.2.7-SNAPSHOT' with configuration '/Users/ahenning/Code/jmxtrans-agent/sample-config.xml'...
2017-12-02 19:30:45.77 INFO [jmxtrans-agent-delayed-starter-waitForMBeanServer] org.jmxtrans.agent.JmxTransAgent - PropertiesLoader: Empty Properties Loader
19:30:55,322 INFO  [org.jboss.msc] (main) JBoss MSC version 1.2.7.SP1-redhat-1
19:30:55,433 INFO  [org.jboss.as] (MSC service thread 1-7) WFLYSRV0049: JBoss EAP 7.1.0.GA (WildFly Core 3.0.10.Final-redhat-1) starting
```

