### PR TITLE
Add counter type support to invocations

### DIFF
--- a/src/main/java/org/jmxtrans/agent/ConsoleOutputWriter.java
+++ b/src/main/java/org/jmxtrans/agent/ConsoleOutputWriter.java
@@ -46,7 +46,7 @@ public class ConsoleOutputWriter extends AbstractOutputWriter implements OutputW
 
     @Override
     public void writeQueryResult(@Nonnull String name, @Nullable String type, @Nullable Object value) {
-        System.out.println(metricPathPrefix + name + " " + value + " " + TimeUnit.SECONDS.convert(System.currentTimeMillis(), TimeUnit.MILLISECONDS));
+        System.out.println(metricPathPrefix + name + " " + value + " " + TimeUnit.SECONDS.convert(System.currentTimeMillis(), TimeUnit.MILLISECONDS) + " " + type);
     }
 
     @Override

--- a/src/main/java/org/jmxtrans/agent/Invocation.java
+++ b/src/main/java/org/jmxtrans/agent/Invocation.java
@@ -46,6 +46,8 @@ public class Invocation implements Collector {
     protected final String operationName;
     @Nullable
     protected final String resultAlias;
+    @Nullable
+    protected final String type;
     @Nonnull
     protected final Object[] params;
     @Nonnull
@@ -55,7 +57,7 @@ public class Invocation implements Collector {
     private Integer collectInterval;
 
     public Invocation(@Nullable String objectName, @Nonnull String operationName, @Nonnull Object[] params, @Nonnull String[] signature, @Nullable String resultAlias,
-            @Nullable Integer collectInterval) {
+            @Nullable Integer collectInterval, @Nullable String type) {
         try {
             this.objectName = objectName == null ? null : new ObjectName(objectName);
         } catch (MalformedObjectNameException e) {
@@ -66,6 +68,7 @@ public class Invocation implements Collector {
         this.signature = Preconditions2.checkNotNull(signature, "signature");
         this.resultAlias = resultAlias;
         this.collectInterval = collectInterval;
+        this.type = (type == null || type.isEmpty()) ? "counter" : type;
     }
 
     private void invoke(MBeanServer mbeanServer, OutputWriter outputWriter) {
@@ -86,6 +89,7 @@ public class Invocation implements Collector {
                 "objectName=" + objectName +
                 ", operationName='" + operationName + '\'' +
                 ", resultAlias='" + resultAlias + '\'' +
+                ", type='" + type + '\'' +
                 ", params=" + Arrays.toString(params) +
                 ", signature=" + Arrays.toString(signature) +
                 '}';

--- a/src/main/java/org/jmxtrans/agent/Invocation.java
+++ b/src/main/java/org/jmxtrans/agent/Invocation.java
@@ -76,7 +76,7 @@ public class Invocation implements Collector {
         for (ObjectName on : objectNames) {
             try {
                 Object result = mbeanServer.invoke(on, operationName, params, signature);
-                outputWriter.writeInvocationResult(resultAlias, result);
+                outputWriter.writeQueryResult(resultAlias, type, result);
             } catch (Exception e) {
                 logger.log(Level.WARNING, "Exception invoking " + on + "#" + operationName + "(" + Arrays.toString(params) + ")", e);
             }

--- a/src/main/java/org/jmxtrans/agent/JmxTransConfigurationXmlLoader.java
+++ b/src/main/java/org/jmxtrans/agent/JmxTransConfigurationXmlLoader.java
@@ -244,9 +244,10 @@ public class JmxTransConfigurationXmlLoader implements JmxTransConfigurationLoad
             String objectName = invocationElement.getAttribute("objectName");
             String operation = invocationElement.getAttribute("operation");
             String resultAlias = invocationElement.getAttribute("resultAlias");
+            String type = invocationElement.getAttribute("type");
             Integer collectInterval = intAttributeOrNull(invocationElement, COLLECT_INTERVAL_NAME);
 
-            configuration.withInvocation(objectName, operation, resultAlias, collectInterval);
+            configuration.withInvocation(objectName, operation, resultAlias, collectInterval, type);
         }
     }
 

--- a/src/main/java/org/jmxtrans/agent/JmxTransExporterConfiguration.java
+++ b/src/main/java/org/jmxtrans/agent/JmxTransExporterConfiguration.java
@@ -77,8 +77,8 @@ public class JmxTransExporterConfiguration {
         queries.add(query);
         return this;
     }
-    public JmxTransExporterConfiguration withInvocation(@Nonnull String objectName, @Nonnull String operation, @Nullable String resultAlias, @Nullable Integer collectInterval) {
-        invocations.add(new Invocation(objectName, operation, new Object[0], new String[0], resultAlias, collectInterval));
+    public JmxTransExporterConfiguration withInvocation(@Nonnull String objectName, @Nonnull String operation, @Nullable String resultAlias, @Nullable Integer collectInterval, @Nullable String type) {
+        invocations.add(new Invocation(objectName, operation, new Object[0], new String[0], resultAlias, collectInterval, type));
         return this;
     }
     public JmxTransExporterConfiguration withOutputWriter(OutputWriter outputWriter) {


### PR DESCRIPTION
Invocations were always getting counted as counters because writeInvocation always ended up as writeQueryResult with null passed as the type. I've short circuited that and wired up the 'type' parameter similar to query.

I'm not married to the change to ConsoleOutputWriter to log what type the metric is.