### PR TITLE
Adds support for filtering out non float values before sending

### DIFF
--- a/src/main/java/org/jmxtrans/agent/graphite/GraphiteMetricMessageBuilder.java
+++ b/src/main/java/org/jmxtrans/agent/graphite/GraphiteMetricMessageBuilder.java
@@ -50,13 +50,17 @@ public class GraphiteMetricMessageBuilder {
      * @return The metric string without trailing newline
      */
     public String buildMessage(String metricName, Object value, long timestamp) {
-        if (value instanceof Boolean) {
-            return metricPathPrefix + metricName + " " + ((Boolean)value ? 1 : 0) + " " + timestamp;
-        }
-        return metricPathPrefix + metricName + " " + value + " " + timestamp;
+        return metricPathPrefix + metricName + " " + convertToString(value) + " " + timestamp;
     }
     
-    /**
+    private String convertToString(Object value) {
+    	if (value instanceof Boolean) {
+            return (Boolean)value ? "1" : "0";
+        }
+    	return String.valueOf(value);
+	}
+
+	/**
      * {@link java.net.InetAddress#getLocalHost()} may not be known at JVM startup when the process is launched as a Linux service.
      */
     private static String buildMetricPathPrefix(String configuredMetricPathPrefix) {
@@ -75,5 +79,15 @@ public class GraphiteMetricMessageBuilder {
     public String getPrefix() {
         return metricPathPrefix;
     }
-        
+
+    /**
+     * Checks if the given value can be sent as a float value to graphite.
+     * Note that Booleans are converted to 1/0 and will pass this check  
+     * 
+     * @param value value to check
+     * @return true if the string representation of value is parseable as a float
+     */
+    public boolean isFloat(Object value) {
+    	return convertToString(value).matches("[-+]?[0-9]*\\.?[0-9]+");
+    }
 }

--- a/src/main/java/org/jmxtrans/agent/graphite/GraphiteOutputWriterCommonSettings.java
+++ b/src/main/java/org/jmxtrans/agent/graphite/GraphiteOutputWriterCommonSettings.java
@@ -23,7 +23,9 @@
  */
 package org.jmxtrans.agent.graphite;
 
-import static org.jmxtrans.agent.util.ConfigurationUtils.*;
+import static org.jmxtrans.agent.util.ConfigurationUtils.getBoolean;
+import static org.jmxtrans.agent.util.ConfigurationUtils.getInt;
+import static org.jmxtrans.agent.util.ConfigurationUtils.getString;
 
 import java.util.Map;
 
@@ -38,6 +40,7 @@ public class GraphiteOutputWriterCommonSettings {
     public static final String SETTING_PORT = "port";
     public static final int SETTING_PORT_DEFAULT_VALUE = 2003;
     public static final String SETTING_NAME_PREFIX = "namePrefix";
+    public static final String SETTING_FILTER_NON_FLOAT = "filterNonFloatValues";
     
     private GraphiteOutputWriterCommonSettings(){}
     
@@ -48,5 +51,9 @@ public class GraphiteOutputWriterCommonSettings {
     
     public static String getConfiguredMetricPrefixOrNull(Map<String, String> settings) {
         return getString(settings, SETTING_NAME_PREFIX, null);
+    }
+    
+    public static boolean filterNonFloatValues(Map<String,String> settings) {
+        return getBoolean(settings, "filterNonFloatValues", false);
     }
 }

--- a/src/test/java/org/jmxtrans/agent/GraphiteMetricMessageBuilderTest.java
+++ b/src/test/java/org/jmxtrans/agent/GraphiteMetricMessageBuilderTest.java
@@ -23,8 +23,12 @@
  */
 package org.jmxtrans.agent;
 
-import static org.hamcrest.Matchers.*;
-import static org.junit.Assert.*;
+import static org.hamcrest.Matchers.endsWith;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.startsWith;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
 
 import org.jmxtrans.agent.graphite.GraphiteMetricMessageBuilder;
 import org.junit.Test;
@@ -62,4 +66,18 @@ public class GraphiteMetricMessageBuilderTest {
         String msg = builder.buildMessage("bar", false, 11);
         assertThat(msg, equalTo("foo.bar 0 11"));
     }
+
+    @Test
+	public void checksFloatValues() throws Exception {
+        GraphiteMetricMessageBuilder builder = new GraphiteMetricMessageBuilder("foo.");
+        assertTrue(builder.isFloat("1.23"));
+        assertTrue(builder.isFloat("1"));
+        assertTrue(builder.isFloat("-1.23"));
+        assertTrue(builder.isFloat("0"));
+        assertTrue(builder.isFloat(false));
+        assertTrue(builder.isFloat(true));
+        assertFalse(builder.isFloat(""));
+        assertFalse(builder.isFloat(null));
+        assertFalse(builder.isFloat("qwerty"));
+	}
 }


### PR DESCRIPTION
To avoid server side parse errors, do not bother sending string values
or null to graphite.

Added xml configuration value "filterNonFloatValues" that defaults to
false