### PR TITLE
Add CloudWatchOutputWriter using the v2 AWS SDK and async cloudwatch client

### DIFF
--- a/README.md
+++ b/README.md
@@ -275,6 +275,9 @@ Out of the box output writers:
   * `retentionPolicy`: retention policy to use - optional
   * `connectTimeoutMillis`: connect timeout for the HTTP connection to influx - optional, defaults to 3000
   * `readTimeoutMillis`: read timeout for the HTTP connection to influx - optional, defaults to 5000
+* [CloudWatchOutputWriter](https://github.com/jmxtrans/jmxtrans-agent/blob/master/src/main/java/org/jmxtrans/agent/CloudWatchOutputWriter.java): Output to AWS CloudWatch Metrics. Credentials and region are loaded using the default region and credential providers (https://sdk.amazonaws.com/java/api/latest/software/amazon/awssdk/services/cloudwatch/CloudWatchClient.html#create--). Configuration parameters:
+  * `namespace`: Cloudwatch namespace. Default is "JMX".  e.g. `JMX/Production`. - optional
+  * `dimensions`: additional dimensions to use for all metrics. Use `n1:v1,n2:v2` format, e.g. `<dimensions>host:#hostname#</dimensions>` - optional
 
 
 Output writers configuration support an [expression language](https://github.com/jmxtrans/jmxtrans-agent/wiki/Expression-Language) based on property placeholders with the `{prop-name[:default-value]}` syntax (e.g. "`${graphite.port:2003}`").
@@ -363,6 +366,13 @@ tomcat.bytesSent 0
 tomcat.bytesReceived 0
 tomcat.bytesReceived 0
 application.activeSessions 0
+```
+
+# Building
+
+```
+mvn compile
+mvn package
 ```
 
 

--- a/pom.xml
+++ b/pom.xml
@@ -40,6 +40,17 @@
     <url>https://github.com/jmxtrans/jmxtrans-agent</url>
     <tag>HEAD</tag>
   </scm>
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>software.amazon.awssdk</groupId>
+        <artifactId>bom</artifactId>
+        <version>2.13.0</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
   <dependencies>
     <dependency>
       <groupId>com.sun</groupId>
@@ -90,14 +101,16 @@
       <version>2.5.1</version>
       <scope>test</scope>
     </dependency>
-
+    <dependency>
+      <groupId>software.amazon.awssdk</groupId>
+      <artifactId>cloudwatch</artifactId>
+    </dependency>
   </dependencies>
   <build>
     <plugins>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-jar-plugin</artifactId>
-        <version>3.0.2</version>
+        <artifactId>maven-assembly-plugin</artifactId>
         <configuration>
           <archive>
             <manifest>
@@ -111,14 +124,28 @@
             </manifestEntries>
           </archive>
         </configuration>
+        <executions>
+           <execution>
+              <id>create-my-bundle</id>
+              <phase>package</phase>
+              <goals>
+                 <goal>single</goal>
+              </goals>
+              <configuration>
+                 <descriptorRefs>
+                    <descriptorRef>jar-with-dependencies</descriptorRef>
+                 </descriptorRefs>
+              </configuration>
+           </execution>
+        </executions>
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
         <version>3.6.1</version>
         <configuration>
-          <source>1.7</source>
-          <target>1.7</target>
+          <source>1.8</source>
+          <target>1.8</target>
         </configuration>
       </plugin>
       <plugin>

--- a/src/main/java/org/jmxtrans/agent/CloudWatchOutputWriter.java
+++ b/src/main/java/org/jmxtrans/agent/CloudWatchOutputWriter.java
@@ -1,0 +1,81 @@
+package org.jmxtrans.agent;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.logging.Level;
+import org.jmxtrans.agent.util.ConfigurationUtils;
+import software.amazon.awssdk.services.cloudwatch.CloudWatchAsyncClient;
+import software.amazon.awssdk.services.cloudwatch.model.CloudWatchException;
+import software.amazon.awssdk.services.cloudwatch.model.Dimension;
+import software.amazon.awssdk.services.cloudwatch.model.MetricDatum;
+import software.amazon.awssdk.services.cloudwatch.model.PutMetricDataRequest;
+
+public class CloudWatchOutputWriter extends AbstractOutputWriter {
+
+  private CloudWatchAsyncClient client;
+  private String configNamespace;
+  private String configDimensions;
+  private List<Tag> listOfDimensions;
+  private Collection<Dimension> dimensions;
+
+  @Override
+  public void postConstruct(Map<String, String> settings) {
+
+    client = CloudWatchAsyncClient.create();
+    configNamespace = ConfigurationUtils.getString(settings, "namespace", "JMX");
+    configDimensions = ConfigurationUtils.getString(settings, "dimensions", "");
+    listOfDimensions = Tag.tagsFromCommaSeparatedString(configDimensions);
+
+    dimensions = new ArrayList<Dimension>();
+
+    for (Tag thisDimension : listOfDimensions) {
+      dimensions.add(
+          Dimension.builder()
+              .name(thisDimension.getName())
+              .value(thisDimension.getValue())
+              .build());
+    }
+  }
+
+  @Override
+  public void writeQueryResult(String name, String type, Object value) {
+
+    Double doubleValue;
+
+    if (value instanceof Number) {
+      Number numberValue = (Number) value;
+      doubleValue = numberValue.doubleValue();
+    } else {
+      logger.log(Level.WARNING, "Cannot write result " + name + ". " + value + " is not a Number.");
+      return;
+    }
+
+    try {
+
+      MetricDatum datum =
+          MetricDatum.builder().metricName(name).value(doubleValue).dimensions(dimensions).build();
+
+      PutMetricDataRequest request =
+          PutMetricDataRequest.builder().namespace(configNamespace).metricData(datum).build();
+
+      client.putMetricData(request);
+
+    } catch (CloudWatchException e) {
+      logger.log(Level.SEVERE, e.awsErrorDetails().errorMessage());
+    }
+  }
+
+  @Override
+  public void writeInvocationResult(String invocationName, Object value) throws IOException {
+    writeQueryResult(invocationName, null, value);
+  }
+
+  @Override
+  public void preDestroy() {
+    super.preDestroy();
+    client.close();
+  }
+}


### PR DESCRIPTION
Tested on OpenJDK 1.8

- Single jar execution goal was added to include AWS SDK
- Maven plugin source/target 1.8 version was required to support the single jar build
- Using maven-assembly-plugin instead of maven-jar-plugin to support single jar build.