### PR TITLE
skip NaN value in StatsDOutputWriter

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: java
 sudo: false
 jdk:
   - oraclejdk8
+  - openjdk11
   - openjdk7
 cache:
   directories:

--- a/src/main/java/org/jmxtrans/agent/StatsDOutputWriter.java
+++ b/src/main/java/org/jmxtrans/agent/StatsDOutputWriter.java
@@ -131,6 +131,14 @@ public class StatsDOutputWriter extends AbstractOutputWriter implements OutputWr
     @Override
     public synchronized void writeQueryResult(String metricName, String metricType, Object value) throws IOException
     {
+        // statsd expects a number value for the metric.
+        //
+        // skip if value's string representation equals to "NaN", which is a meaningless value to statsd.
+        // passing the NaN value down will trigger error in downstream parsing applications.
+        if (String.valueOf(value).equals("NaN")) {
+            return;
+        }
+
         //DataDog statsd with tags (https://docs.datadoghq.com/guides/dogstatsd/),
         // metric.name:value|type|@sample_rate|#tag1:value,tag2
         //Sysdig metric tags (https://support.sysdig.com/hc/en-us/articles/204376099-Metrics-integrations-StatsD-)

--- a/src/main/java/org/jmxtrans/agent/StatsDOutputWriter.java
+++ b/src/main/java/org/jmxtrans/agent/StatsDOutputWriter.java
@@ -135,7 +135,8 @@ public class StatsDOutputWriter extends AbstractOutputWriter implements OutputWr
         //
         // skip if value's string representation equals to "NaN" or "INF", which are meaningless values to statsd.
         // passing the invalid values down will trigger error in downstream parsing applications.
-        if (String.valueOf(value).equals("NaN") || String.valueOf(value).equals("INF")) {
+        String strValue = String.valueOf(value);
+        if (strValue.equals("NaN") || strValue.equals("INF")) {
             return;
         }
 
@@ -150,7 +151,7 @@ public class StatsDOutputWriter extends AbstractOutputWriter implements OutputWr
                     .append(".")
                     .append(metricName)
                     .append(":")
-                    .append(value)
+                    .append(strValue)
                     .append("|")
                     .append(type)
                     .append("|#")
@@ -163,7 +164,7 @@ public class StatsDOutputWriter extends AbstractOutputWriter implements OutputWr
                     .append("#")
                     .append(StringUtils2.join(Tag.convertTagsToStrings(tags), ","))
                     .append(":")
-                    .append(value)
+                    .append(strValue)
                     .append("|")
                     .append(type)
                     .append("\n");
@@ -172,7 +173,7 @@ public class StatsDOutputWriter extends AbstractOutputWriter implements OutputWr
                     .append(".")
                     .append(metricName)
                     .append(":")
-                    .append(value)
+                    .append(strValue)
                     .append("|")
                     .append(type)
                     .append("\n");

--- a/src/main/java/org/jmxtrans/agent/StatsDOutputWriter.java
+++ b/src/main/java/org/jmxtrans/agent/StatsDOutputWriter.java
@@ -133,9 +133,9 @@ public class StatsDOutputWriter extends AbstractOutputWriter implements OutputWr
     {
         // statsd expects a number value for the metric.
         //
-        // skip if value's string representation equals to "NaN", which is a meaningless value to statsd.
+        // skip if value's string representation equals to "NaN" or "INF", which is a meaningless value to statsd.
         // passing the NaN value down will trigger error in downstream parsing applications.
-        if (String.valueOf(value).equals("NaN")) {
+        if (String.valueOf(value).equals("NaN") || String.valueOf(value).equals("INF")) {
             return;
         }
 

--- a/src/main/java/org/jmxtrans/agent/StatsDOutputWriter.java
+++ b/src/main/java/org/jmxtrans/agent/StatsDOutputWriter.java
@@ -133,8 +133,8 @@ public class StatsDOutputWriter extends AbstractOutputWriter implements OutputWr
     {
         // statsd expects a number value for the metric.
         //
-        // skip if value's string representation equals to "NaN" or "INF", which is a meaningless value to statsd.
-        // passing the NaN value down will trigger error in downstream parsing applications.
+        // skip if value's string representation equals to "NaN" or "INF", which are meaningless values to statsd.
+        // passing the invalid values down will trigger error in downstream parsing applications.
         if (String.valueOf(value).equals("NaN") || String.valueOf(value).equals("INF")) {
             return;
         }

--- a/src/test/java/org/jmxtrans/agent/StatsDOutputWriterTest.java
+++ b/src/test/java/org/jmxtrans/agent/StatsDOutputWriterTest.java
@@ -113,6 +113,19 @@ public class StatsDOutputWriterTest {
 
     }
 
+    @Test
+    public void test_skip_counter_with_NaN_value() throws IOException {
+        Map<String, String> settings = new HashMap<>();
+        settings.put(StatsDOutputWriter.SETTING_ROOT_PREFIX, "foo.bar");
+        // No real connect is done. Config is here to please the postConstruct.
+        settings.put(StatsDOutputWriter.SETTING_HOST, "localhost");
+        settings.put(StatsDOutputWriter.SETTING_PORT, "8125");
+
+        writer.postConstruct(settings);
+        writer.writeQueryResult("my-metric", "gauge", "NaN");
+        Assert.assertNull(writer.receivedStat);
+    }
+
     /**
      * https://github.com/jmxtrans/jmxtrans-agent/issues/98
      */

--- a/src/test/java/org/jmxtrans/agent/StatsDOutputWriterTest.java
+++ b/src/test/java/org/jmxtrans/agent/StatsDOutputWriterTest.java
@@ -124,6 +124,9 @@ public class StatsDOutputWriterTest {
         writer.postConstruct(settings);
         writer.writeQueryResult("my-metric", "gauge", "NaN");
         Assert.assertNull(writer.receivedStat);
+
+        writer.writeQueryResult("my-metric", "gauge", "INF");
+        Assert.assertNull(writer.receivedStat);
     }
 
     /**


### PR DESCRIPTION
skip "NaN" or "INF" value in StatsDOutputWriter

this is for resolving issue when integrates jmxtrans-agent with Kafka Connect. the MBean of kafka connect sometimes emits NaN as the value for StatsDOutputWriter as the following.

> can't enable for offset-commit-max-time-ms, err msg as
             Invalid value "dynamostreamskafkaconector.task.offset-commit-max-time-ms,connector=firehose-connector,task=1:NaN|g" supplied (NaN or INF)
