### PR TITLE
Refactored the tags parsing and message construction so it can be sub…

### DIFF
--- a/src/main/java/org/jmxtrans/agent/StatsDOutputWriter.java
+++ b/src/main/java/org/jmxtrans/agent/StatsDOutputWriter.java
@@ -71,7 +71,8 @@ public class StatsDOutputWriter extends AbstractOutputWriter implements OutputWr
             String tagsStr = ConfigurationUtils.getString(settings, SETTINGS_TAGS, "");
             tags = Tag.tagsFromCommaSeparatedString(tagsStr, "=");
             metricNamePrefix = ConfigurationUtils.getString(settings, SETTING_ROOT_PREFIX, getHostName().replaceAll("\\.", "_"));
-        } else {
+        }
+        else {
             metricNamePrefix = ConfigurationUtils.getString(settings, SETTING_ROOT_PREFIX, getHostName().replaceAll("\\.", "_"));
         }
     }

--- a/src/main/java/org/jmxtrans/agent/StatsDOutputWriter.java
+++ b/src/main/java/org/jmxtrans/agent/StatsDOutputWriter.java
@@ -140,35 +140,35 @@ public class StatsDOutputWriter extends AbstractOutputWriter implements OutputWr
         String type = "gauge".equalsIgnoreCase(metricType) || "g".equalsIgnoreCase(metricType) ? "g" : "c";
         if (statsType.equals(STATSD_DATADOG)) {
             sb.append(metricNamePrefix)
-                .append(".")
-                .append(metricName)
-                .append(":")
-                .append(strValue)
-                .append("|")
-                .append(type)
-                .append("|#")
-                .append(StringUtils2.join(Tag.convertTagsToStrings(tags), ","))
-                .append("\n");
+                    .append(".")
+                    .append(metricName)
+                    .append(":")
+                    .append(strValue)
+                    .append("|")
+                    .append(type)
+                    .append("|#")
+                    .append(StringUtils2.join(Tag.convertTagsToStrings(tags), ","))
+                    .append("\n");
         } else if (statsType.equals(STATSD_SYSDIG)) {
             sb.append(metricNamePrefix)
-                .append(".")
-                .append(metricName)
-                .append("#")
-                .append(StringUtils2.join(Tag.convertTagsToStrings(tags), ","))
-                .append(":")
-                .append(strValue)
-                .append("|")
-                .append(type)
-                .append("\n");
+                    .append(".")
+                    .append(metricName)
+                    .append("#")
+                    .append(StringUtils2.join(Tag.convertTagsToStrings(tags), ","))
+                    .append(":")
+                    .append(strValue)
+                    .append("|")
+                    .append(type)
+                    .append("\n");
         } else {
             sb.append(metricNamePrefix)
-                .append(".")
-                .append(metricName)
-                .append(":")
-                .append(strValue)
-                .append("|")
-                .append(type)
-                .append("\n");
+                    .append(".")
+                    .append(metricName)
+                    .append(":")
+                    .append(strValue)
+                    .append("|")
+                    .append(type)
+                    .append("\n");
         }
         return sb.toString();
     }


### PR DESCRIPTION
…classed more easily.
This is needed since main fields (e.g. `statsType`, `tags`) are `private` instead of `protected`, which means that the child class can not override the parsing easily.