### PR TITLE
Fixed the JDK version compatibility issue with Buffer class

### DIFF
--- a/src/main/java/org/jmxtrans/agent/StatsDOutputWriter.java
+++ b/src/main/java/org/jmxtrans/agent/StatsDOutputWriter.java
@@ -23,6 +23,7 @@
  */
 package org.jmxtrans.agent;
 
+import java.nio.Buffer;
 import org.jmxtrans.agent.util.CachingReference;
 import org.jmxtrans.agent.util.ConfigurationUtils;
 import org.jmxtrans.agent.util.StringUtils2;
@@ -228,7 +229,7 @@ public class StatsDOutputWriter extends AbstractOutputWriter implements OutputWr
             } // empty buffer
 
             // send and reset the buffer
-            sendBuffer.flip();
+            ((Buffer)sendBuffer).flip();
             final int nbSentBytes = channel.send(sendBuffer, address);
             sendBuffer.limit(sendBuffer.capacity());
             sendBuffer.rewind();


### PR DESCRIPTION
This should address the issue when running with a different JRE than the compilation version:
https://stackoverflow.com/questions/61267495/exception-in-thread-main-java-lang-nosuchmethoderror-java-nio-bytebuffer-flip