### PR TITLE
Fix dogstatsd metric without tags in StatsDOutputWriter

### DIFF
--- a/src/main/java/org/jmxtrans/agent/StatsDOutputWriter.java
+++ b/src/main/java/org/jmxtrans/agent/StatsDOutputWriter.java
@@ -147,10 +147,12 @@ public class StatsDOutputWriter extends AbstractOutputWriter implements OutputWr
                     .append(":")
                     .append(strValue)
                     .append("|")
-                    .append(type)
-                    .append("|#")
-                    .append(StringUtils2.join(Tag.convertTagsToStrings(tags), ","))
-                    .append("\n");
+                    .append(type);
+            if (!tags.isEmpty()) {
+                sb.append("|#");
+                sb.append(StringUtils2.join(Tag.convertTagsToStrings(tags), ","));
+            }
+            sb.append("\n");
         } else if (statsType.equals(STATSD_SYSDIG)) {
             sb.append(metricNamePrefix)
                     .append(".")

--- a/src/test/java/org/jmxtrans/agent/StatsDOutputWriterTest.java
+++ b/src/test/java/org/jmxtrans/agent/StatsDOutputWriterTest.java
@@ -88,6 +88,20 @@ public class StatsDOutputWriterTest {
     }
 
     @Test
+    public void test_write_counter_metric_dd_without_tags() throws IOException {
+        Map<String, String> settings = new HashMap<>();
+        settings.put(StatsDOutputWriter.SETTING_ROOT_PREFIX, "foo.bar");
+        // No real connect is done. Config is here to please the postConstruct.
+        settings.put(StatsDOutputWriter.SETTING_HOST, "localhost");
+        settings.put(StatsDOutputWriter.SETTING_PORT, "8125");
+        settings.put(StatsDOutputWriter.SETTINGS_STATSD_TYPE, "dd");
+
+        writer.postConstruct(settings);
+        writer.writeQueryResult("my-metric", "gauge", 12);
+        Assert.assertThat(writer.receivedStat, equalTo("foo.bar.my-metric:12|g\n"));
+    }
+
+    @Test
     public void test_write_counter_metric_sysdig() throws IOException {
         Map<String, String> settings = new HashMap<>();
         settings.put(StatsDOutputWriter.SETTING_ROOT_PREFIX, "foo.bar");


### PR DESCRIPTION
In DogStatsD format, metrics without tags shall not contain `|#`. See [data dog python library](https://github.com/DataDog/datadogpy/blob/63d0c01b5bbcb8158cf3ddab153639951ab44945/datadog/dogstatsd/base.py#L770) for implementation details